### PR TITLE
Re-organise the command-line interface

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,9 @@ jobs:
           name: Install hledger-flow executable
           command: stack install
       - run:
+          name: hledger-flow --help
+          command: ~/.local/bin/hledger-flow --help
+      - run:
           name: hledger-flow --version
           command: ~/.local/bin/hledger-flow --version
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,10 +45,10 @@ jobs:
           command: git clone --recurse-submodules https://github.com/apauley/hledger-flow-example.git $HOME/hledger-flow-example
       - run:
           name: hledger-flow import
-          command: ~/.local/bin/hledger-flow --verbose import --show-options $HOME/hledger-flow-example
+          command: ~/.local/bin/hledger-flow --verbose --show-options import $HOME/hledger-flow-example
       - run:
           name: hledger-flow report
-          command: ~/.local/bin/hledger-flow --verbose report --show-options $HOME/hledger-flow-example
+          command: ~/.local/bin/hledger-flow --verbose --show-options report $HOME/hledger-flow-example
       - run:
           name: Undo package.yaml change before cache_save
           command: git checkout HEAD package.yaml

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,8 +56,8 @@ install:
 script:
   - stack test --interleaved-output
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git checkout HEAD package.yaml; fi
-  - hledger-flow --verbose import --show-options $HOME/hledger-flow-example
-  - hledger-flow --verbose report --show-options $HOME/hledger-flow-example
+  - hledger-flow --verbose --show-options import $HOME/hledger-flow-example
+  - hledger-flow --verbose --show-options report $HOME/hledger-flow-example
 
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ install:
   - stack build --interleaved-output --test --bench --no-run-tests --no-run-benchmarks
   - stack install
   - which hledger-flow
+  - hledger-flow --help
   - hledger-flow --version
   - ldd $(which hledger-flow) || true
   - ./bin/release-tarball ~/.local/bin/hledger-flow

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for [hledger-flow](https://github.com/apauley/hledger-flow)
 
+## 0.12.0
+
+- Re-organised the command-line interface:
+  moved various command-line options out of subcommands, into the top-level.
+- Added a [contributor's agreement](https://github.com/apauley/hledger-flow/blob/master/CONTRIBUTING.org)
+  after receiving some more valued contributions from
+  [jecaro](https://github.com/apauley/hledger-flow/pull/42)
+
 ## 0.11.3
 
 - Detect the hledger-flow base directory correctly, even when in a subdirectory. Similar to how git behaves.

--- a/README.org
+++ b/README.org
@@ -113,9 +113,9 @@ likely change.
 
 Let me know if you can think of some improvements.
 
-* Detailed Step-By-Step Guide
+* Getting Started
   :PROPERTIES:
-  :CUSTOM_ID: detailed-step-by-step-guide
+  :CUSTOM_ID: getting-started
   :END:
 
 Have a look at the [[file:docs/README.org][detailed step-by-step

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -57,7 +57,7 @@ baseCommandParser = (Command <$> verboseParser <*> commandParser)
   <|> flag' Version (long "version" <> short 'V' <> help "Display version information")
 
 commandParser :: Parser Command
-commandParser = fmap Import (subcommand "import" "Converts CSV transactions into categorised journal files" subcommandParser)
+commandParser = fmap Import (subcommand "import" "Converts electronic transactions into categorised journal files" subcommandParser)
   <|> fmap Report (subcommand "report" "Generate Reports" subcommandParser)
 
 verboseParser :: Parser MainParams

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,15 +14,14 @@ import Hledger.Flow.Common
 import Hledger.Flow.Reports
 import Hledger.Flow.CSVImport
 
-data SubcommandParams = SubcommandParams { maybeBaseDir :: Maybe FilePath
-                                         , hledgerPathOpt :: Maybe FilePath
-                                         , showOpts :: Bool
-                                         , sequential :: Bool
-                                         }
-                      deriving (Show)
+data SubcommandParams = SubcommandParams { maybeBaseDir :: Maybe FilePath } deriving (Show)
 data Command = Import SubcommandParams | Report SubcommandParams deriving (Show)
 
-data MainParams = MainParams { verbose :: Bool } deriving (Show)
+data MainParams = MainParams { verbose :: Bool
+                             , hledgerPathOpt :: Maybe FilePath
+                             , showOpts :: Bool
+                             , sequential :: Bool
+                             } deriving (Show)
 data BaseCommand = Version | Command { mainParams :: MainParams, command :: Command } deriving (Show)
 
 main :: IO ()
@@ -34,24 +33,24 @@ main = do
     Command mainParams' (Report subParams) -> toReportOptions mainParams' subParams >>= generateReports
 
 toImportOptions :: MainParams -> SubcommandParams -> IO IT.ImportOptions
-toImportOptions mainParams' params = do
-  bd <- determineBaseDir $ maybeBaseDir params
-  hli <- hledgerInfoFromPath $ hledgerPathOpt params
+toImportOptions mainParams' subParams' = do
+  bd <- determineBaseDir $ maybeBaseDir subParams'
+  hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return IT.ImportOptions { IT.baseDir = bd
                           , IT.hledgerInfo = hli
                           , IT.verbose = verbose mainParams'
-                          , IT.showOptions = showOpts params
-                          , IT.sequential = sequential params }
+                          , IT.showOptions = showOpts mainParams'
+                          , IT.sequential = sequential mainParams' }
 
 toReportOptions :: MainParams -> SubcommandParams -> IO RT.ReportOptions
-toReportOptions mainParams' params = do
-  bd <- determineBaseDir $ maybeBaseDir params
-  hli <- hledgerInfoFromPath $ hledgerPathOpt params
+toReportOptions mainParams' subParams' = do
+  bd <- determineBaseDir $ maybeBaseDir subParams'
+  hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return RT.ReportOptions { RT.baseDir = bd
                           , RT.hledgerInfo = hli
                           , RT.verbose = verbose mainParams'
-                          , RT.showOptions = showOpts params
-                          , RT.sequential = sequential params }
+                          , RT.showOptions = showOpts mainParams'
+                          , RT.sequential = sequential mainParams' }
 
 baseCommandParser :: Parser BaseCommand
 baseCommandParser = (Command <$> verboseParser <*> commandParser)
@@ -64,10 +63,10 @@ commandParser = fmap Import (subcommand "import" "Converts CSV transactions into
 verboseParser :: Parser MainParams
 verboseParser = MainParams
   <$> switch (long "verbose" <> short 'v' <> help "Print more verbose output")
+  <*> optional (optPath "hledger-path" 'H' "The full path to an hledger executable")
+  <*> switch (long "show-options" <> help "Print the options this program will run with")
+  <*> switch (long "sequential" <> help "Disable parallel processing")
 
 subcommandParser :: Parser SubcommandParams
 subcommandParser = SubcommandParams
   <$> optional (argPath "basedir" "The hledger-flow base directory")
-  <*> optional (optPath "hledger-path" 'H' "The full path to an hledger executable")
-  <*> switch (long "show-options" <> help "Print the options this program will run with")
-  <*> switch (long "sequential" <> help "Disable parallel processing")

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hledger-flow
-version:             0.11.3.0
+version:             0.12.0.0
 synopsis:            An hledger workflow focusing on automated statement import and classification.
 category:            Finance, Console
 license:             GPL-3

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -393,9 +393,9 @@ changeOutputPath newOutputLocation srcFile = mconcat $ map changeSrcDir $ splitD
   where changeSrcDir file = if (file == "1-in/" || file == "2-preprocessed/") then newOutputLocation else file
 
 errorMessageBaseDir :: FilePath -> Text
-errorMessageBaseDir startDir = format ("Unable to find an hledger-flow import directory at '"%fp
+errorMessageBaseDir startDir = format ("\nUnable to find an hledger-flow import directory at '"%fp
                                        %"' (or in any of its parent directories).\n\n"
-                                       %"Have a look at the documentation for more information:\n"%s)
+                                       %"Have a look at the documentation for more information:\n"%s%"\n")
                                startDir (docURL "input-files")
 
 determineBaseDir :: Maybe FilePath -> IO FilePath

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -404,8 +404,8 @@ determineBaseDir Nothing = pwd >>= determineBaseDir'
 
 determineBaseDir' :: FilePath -> IO FilePath
 determineBaseDir' startDir = do
-  ee <- determineBaseDir'' startDir startDir
-  case ee of
+  ebd <- determineBaseDir'' startDir startDir
+  case ebd of
     Right bd -> return bd
     Left  t  -> die t
 

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -396,7 +396,7 @@ errorMessageBaseDir :: FilePath -> Text
 errorMessageBaseDir startDir = format ("\nUnable to find an hledger-flow import directory at '"%fp
                                        %"' (or in any of its parent directories).\n\n"
                                        %"Have a look at the documentation for more information:\n"%s%"\n")
-                               startDir (docURL "input-files")
+                               startDir (docURL "getting-started")
 
 determineBaseDir :: Maybe FilePath -> IO FilePath
 determineBaseDir (Just suppliedDir) = determineBaseDir' suppliedDir


### PR DESCRIPTION
Re-organised the command-line interface:
  - moved various command-line options out of subcommands, into the top-level.

Fixes #14 
