### PR TITLE
Fix incorrect paths in include files when given a relative base dir

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,6 @@ install:
   - git clone --recurse-submodules https://github.com/apauley/hledger-flow-example.git $HOME/hledger-flow-example
 
 script:
-  - stack test --interleaved-output
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git checkout HEAD package.yaml; fi
   - cd ${HOME} && hledger-flow --verbose --show-options import hledger-flow-example
   - cd /tmp && hledger-flow --verbose --show-options report $HOME/hledger-flow-example

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,8 +55,8 @@ install:
 script:
   - stack test --interleaved-output
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git checkout HEAD package.yaml; fi
-  - hledger-flow --verbose --show-options import $HOME/hledger-flow-example
-  - hledger-flow --verbose --show-options report $HOME/hledger-flow-example
+  - cd ${HOME} && hledger-flow --verbose --show-options import hledger-flow-example
+  - cd /tmp && hledger-flow --verbose --show-options report $HOME/hledger-flow-example
 
 deploy:
   - provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,8 @@ install:
 
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then git checkout HEAD package.yaml; fi
-  - cd ${HOME} && hledger-flow --verbose --show-options import hledger-flow-example
-  - cd /tmp && hledger-flow --verbose --show-options report $HOME/hledger-flow-example
+  - hledger-flow --verbose --show-options import $HOME/hledger-flow-example
+  - hledger-flow --verbose --show-options report $HOME/hledger-flow-example
 
 deploy:
   - provider: releases

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,21 @@
 # Changelog for [hledger-flow](https://github.com/apauley/hledger-flow)
 
+## 0.12.3.1
+
+Fixed a bug where:
+
+Given:
+- A run of `hledger-flow import`
+
+When:
+- specifying a relative import base directory
+- but specifically without any relative prefixes such as `./` or `../`
+
+Then:
+- the account-level include files pointing to the real journal entries would have incorrect paths
+
+https://github.com/apauley/hledger-flow/issues/65
+
 ## 0.12.3
 
 Add more reports:

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hledger-flow
-version:             0.12.3.0
+version:             0.12.3.1
 synopsis:            An hledger workflow focusing on automated statement import and classification.
 category:            Finance, Console
 license:             GPL-3

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -427,7 +427,9 @@ determineBaseDir Nothing = pwd >>= determineBaseDir'
 
 determineBaseDir' :: FilePath -> IO FilePath
 determineBaseDir' startDir = do
-  ebd <- determineBaseDir'' startDir startDir
+  currentDir <- pwd
+  let absoluteStartDir = if relative startDir then collapse (currentDir </> startDir) else startDir
+  ebd <- determineBaseDir'' absoluteStartDir absoluteStartDir
   case ebd of
     Right bd -> return bd
     Left  t  -> die t

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2019-05-26
+resolver: nightly-2019-06-01
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2019-06-01
+resolver: nightly-2019-06-21
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Given:
- A run of `hledger-flow import`

When:
- specifying a relative import base directory
- but specifically without any relative prefixes such as `./` or `../`

Then:
- the account-level include files pointing to the real journal entries would have incorrect paths

Merging this PR should fix #65.
