### PR TITLE
Upgrade to nightly-2019-08-04 - later versions are 404 at the moment

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hledger-flow
-version:             0.12.3.1
+version:             0.12.3.2
 synopsis:            An hledger workflow focusing on automated statement import and classification.
 category:            Finance, Console
 license:             GPL-3

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2019-06-21
+resolver: nightly-2019-08-04
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.


### PR DESCRIPTION
Upgrade to nightly-2019-08-04 - later versions are 404 at the moment