### PR TITLE
Add an experimental rundir option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,19 @@
 # Changelog for [hledger-flow](https://github.com/apauley/hledger-flow)
 
+## 0.13.0
+
+- Add an experimental rundir option for imports
+
+The experimental rundir is an attempt to restrict hledger-flow into processing just a subset of files, primarily to quickly get feedback/failures while adding new accounts to an existing set of accounts.
+
+The use case has been described in [issue 64](https://github.com/apauley/hledger-flow/issues/64).
+
+It is experimental, because the only problem it currently solves is getting hledger-flow to fail fast.
+One of the current side effects of doing so is that the generated include files are then written to only 
+include the subset of files that were processed.
+
+But as soon as you do a full run again, the include files will be correctly re-generated as before.
+
 ## 0.12.4.0
 
 - Update usage of hledger to reflect updated command-line flags of hledger version 1.15

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -12,7 +12,8 @@ import qualified Hledger.Flow.RuntimeOptions as RT
 import Hledger.Flow.Reports
 import Hledger.Flow.CSVImport
 
-data SubcommandParams = SubcommandParams { maybeBaseDir :: Maybe FilePath } deriving (Show)
+data SubcommandParams = SubcommandParams { maybeBaseDir :: Maybe FilePath
+                                         , maybeRunDir :: Maybe FilePath } deriving (Show)
 data Command = Import SubcommandParams | Report SubcommandParams deriving (Show)
 
 data MainParams = MainParams { verbosity :: Int
@@ -35,6 +36,7 @@ toRuntimeOptions mainParams' subParams' = do
   bd <- determineBaseDir $ maybeBaseDir subParams'
   hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return RT.RuntimeOptions { RT.baseDir = bd
+                           , RT.runDir = maybeRunDir subParams'
                            , RT.hfVersion = versionInfo'
                            , RT.hledgerInfo = hli
                            , RT.sysInfo = systemInfo
@@ -60,3 +62,4 @@ verboseParser = MainParams
 subcommandParser :: Parser SubcommandParams
 subcommandParser = SubcommandParams
   <$> optional (argPath "basedir" "The hledger-flow base directory")
+  <*> optional (strOption (long "experimental-rundir" <> help "A subdirectory of the base where the command will restrict itself to"))

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hledger-flow
-version:             0.12.4.0
+version:             0.13.0.0
 synopsis:            An hledger workflow focusing on automated statement import and classification.
 category:            Finance, Console
 license:             GPL-3

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -6,6 +6,7 @@ import Prelude hiding (FilePath, putStrLn)
 import Hledger.Flow.Types
 
 data RuntimeOptions = RuntimeOptions { baseDir :: FilePath
+                                     , runDir :: Maybe FilePath
                                      , hfVersion :: Text
                                      , hledgerInfo :: HledgerInfo
                                      , sysInfo :: SystemInfo
@@ -16,10 +17,10 @@ data RuntimeOptions = RuntimeOptions { baseDir :: FilePath
   deriving (Show)
 
 instance HasVerbosity RuntimeOptions where
-  verbose (RuntimeOptions _ _ _ _ v _ _) = v
+  verbose (RuntimeOptions _ _ _ _ _ v _ _) = v
 
 instance HasSequential RuntimeOptions where
-  sequential (RuntimeOptions _ _ _ _ _ _ sq) = sq
+  sequential (RuntimeOptions _ _ _ _ _ _ _ sq) = sq
 
 instance HasBaseDir RuntimeOptions where
-  baseDir (RuntimeOptions bd _ _ _ _ _ _) = bd
+  baseDir (RuntimeOptions bd _ _ _ _ _ _ _) = bd

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: lts-14.9
+resolver: nightly-2020-02-04
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/test/Common/Integration.hs
+++ b/test/Common/Integration.hs
@@ -28,28 +28,6 @@ testHiddenFiles = TestCase (
      )
   )
 
-testDirOrPwd :: Test
-testDirOrPwd = TestCase (
-  sh (
-      do
-        currentDir <- fmap (\p -> directory (p </> "t")) pwd
-        tmpdir <- using (mktempdir "." "hlflow")
-        let fooDir = collapse $ currentDir </> tmpdir </> "foo/"
-        let barDir = collapse $ currentDir </> tmpdir </> "bar/"
-        mkdir fooDir
-        mkdir barDir
-        d1 <- liftIO $ dirOrPwd Nothing
-        liftIO $ assertEqual "dirOrPwd returns pwd as a fallback" currentDir d1
-        liftIO $ assertEqual "dirOrPwd assumes the fallback is a directory" (directory d1) d1
-        d2 <- liftIO $ dirOrPwd $ Just $ tmpdir </> "foo"
-        liftIO $ assertEqual "dirOrPwd returns the supplied dir - no trailing slash supplied" fooDir d2
-        liftIO $ assertEqual "dirOrPwd assumes the supplied dir is a directory - no trailing slash supplied" (directory d2) d2
-        d3 <- liftIO $ dirOrPwd $ Just $ tmpdir </> "bar/"
-        liftIO $ assertEqual "dirOrPwd returns the supplied dir - trailing slash supplied" barDir d3
-        liftIO $ assertEqual "dirOrPwd assumes the supplied dir is a directory - trailing slash supplied" (directory d3) d3
-     )
-  )
-
 assertSubDirsForDetermineBaseDir :: FilePath -> [FilePath] -> IO ()
 assertSubDirsForDetermineBaseDir expectedBaseDir importDirs = do
   _ <- sequence $ map (assertDetermineBaseDir expectedBaseDir) importDirs
@@ -127,4 +105,4 @@ testFilterPaths = TestCase (
   )
 
 tests :: Test
-tests = TestList [testDirOrPwd, testDetermineBaseDir, testHiddenFiles, testFilterPaths]
+tests = TestList [testDetermineBaseDir, testHiddenFiles, testFilterPaths]

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -59,7 +59,7 @@ defaultHlInfo :: FlowTypes.HledgerInfo
 defaultHlInfo = FlowTypes.HledgerInfo "/path/to/hledger" "1.2.3"
 
 defaultOpts :: FilePath -> RuntimeOptions
-defaultOpts bd = RuntimeOptions bd versionInfo' defaultHlInfo systemInfo False False False
+defaultOpts bd = RuntimeOptions bd Nothing versionInfo' defaultHlInfo systemInfo False False False
 
 toJournals :: [FilePath] -> [FilePath]
 toJournals = map (changePathAndExtension "3-journal" "journal")


### PR DESCRIPTION
The experimental rundir is an attempt to restrict hledger-flow into processing just a subset of files, primarily to quickly get feedback/failures while adding new accounts to an existing set of accounts.

The use case has been described in issue #64.

It is experimental, because the only problem it currently solves is getting hledger-flow to fail fast, and one of the current side effects of doing so is that the generated include files are then written to only include the subset of files that were processed. But as soon as you do a full run again, the include files will be correctly re-generated as before.

Some thought needs to go into properly solving the need for fast failure without causing surprising results. But for now this change should make one of the workarounds currently in use obsolete, namely the use of an old v0.11.1.2 binary which accidentally processed only a subset of files when run in a deeper subdirectory. 

If we can arrive at some behaviour that "does the right thing" while only processing a subset of files, then we can consider enabling this by default whenever the basedir is pointed to a deeper subdirectory.

```
hledger-flow import --help
Usage: hledger-flow import [BASEDIR] [--experimental-rundir ARG]
  Converts electronic transactions into categorised journal files

Available options:
  BASEDIR                  The hledger-flow base directory
  --experimental-rundir ARG
                           A subdirectory of the base where the command will
                           restrict itself to
  -h,--help                Show this help text
```
