### PR TITLE
Replace system-filepath with path

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,25 +5,26 @@ module Main where
 
 import Path
 import Turtle hiding (switch)
-import Prelude hiding (FilePath, putStrLn)
+import Prelude hiding (putStrLn)
 
 import Options.Applicative
 
+import Hledger.Flow.PathHelpers (TurtlePath)
 import Hledger.Flow.Common
 import Hledger.Flow.BaseDir
 import qualified Hledger.Flow.RuntimeOptions as RT
 import Hledger.Flow.Reports
 import Hledger.Flow.CSVImport
 
-data ImportParams = ImportParams { maybeImportBaseDir :: Maybe FilePath
+data ImportParams = ImportParams { maybeImportBaseDir :: Maybe TurtlePath
                                  , importUseRunDir :: Bool } deriving (Show)
 
-data ReportParams = ReportParams { maybeReportBaseDir :: Maybe FilePath } deriving (Show)
+data ReportParams = ReportParams { maybeReportBaseDir :: Maybe TurtlePath } deriving (Show)
 
 data Command = Import ImportParams | Report ReportParams deriving (Show)
 
 data MainParams = MainParams { verbosity :: Int
-                             , hledgerPathOpt :: Maybe FilePath
+                             , hledgerPathOpt :: Maybe TurtlePath
                              , showOpts :: Bool
                              , sequential :: Bool
                              } deriving (Show)
@@ -39,7 +40,7 @@ main = do
 
 toRuntimeOptionsImport :: MainParams -> ImportParams -> IO RT.RuntimeOptions
 toRuntimeOptionsImport mainParams' subParams' = do
-  let maybeBD = maybeImportBaseDir subParams' :: Maybe FilePath
+  let maybeBD = maybeImportBaseDir subParams' :: Maybe TurtlePath
   (bd, runDir) <- determineBaseDir maybeBD
   hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return RT.RuntimeOptions { RT.baseDir = bd
@@ -54,7 +55,7 @@ toRuntimeOptionsImport mainParams' subParams' = do
 
 toRuntimeOptionsReport :: MainParams -> ReportParams -> IO RT.RuntimeOptions
 toRuntimeOptionsReport mainParams' subParams' = do
-  let maybeBD = maybeReportBaseDir subParams' :: Maybe FilePath
+  let maybeBD = maybeReportBaseDir subParams' :: Maybe TurtlePath
   (bd, _) <- determineBaseDir maybeBD
   hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return RT.RuntimeOptions { RT.baseDir = bd

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,13 +1,16 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module Main where
 
+import Path
 import Turtle hiding (switch)
 import Prelude hiding (FilePath, putStrLn)
 
 import Options.Applicative
 
 import Hledger.Flow.Common
+import Hledger.Flow.BaseDir
 import qualified Hledger.Flow.RuntimeOptions as RT
 import Hledger.Flow.Reports
 import Hledger.Flow.CSVImport
@@ -36,7 +39,8 @@ main = do
 
 toRuntimeOptionsImport :: MainParams -> ImportParams -> IO RT.RuntimeOptions
 toRuntimeOptionsImport mainParams' subParams' = do
-  (bd, runDir) <- determineBaseDir $ maybeImportBaseDir subParams'
+  let maybeBD = maybeImportBaseDir subParams' :: Maybe FilePath
+  (bd, runDir) <- determineBaseDir maybeBD
   hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return RT.RuntimeOptions { RT.baseDir = bd
                            , RT.importRunDir = runDir
@@ -50,10 +54,11 @@ toRuntimeOptionsImport mainParams' subParams' = do
 
 toRuntimeOptionsReport :: MainParams -> ReportParams -> IO RT.RuntimeOptions
 toRuntimeOptionsReport mainParams' subParams' = do
-  (bd, _) <- determineBaseDir $ maybeReportBaseDir subParams'
+  let maybeBD = maybeReportBaseDir subParams' :: Maybe FilePath
+  (bd, _) <- determineBaseDir maybeBD
   hli <- hledgerInfoFromPath $ hledgerPathOpt mainParams'
   return RT.RuntimeOptions { RT.baseDir = bd
-                           , RT.importRunDir = "./"
+                           , RT.importRunDir = [reldir|.|]
                            , RT.useRunDir = False
                            , RT.hfVersion = versionInfo'
                            , RT.hledgerInfo = hli

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -4,7 +4,7 @@
 module Main where
 
 import Path
-import Turtle hiding (switch)
+import qualified Turtle as Turtle hiding (switch)
 import Prelude hiding (putStrLn)
 
 import Options.Applicative
@@ -32,9 +32,9 @@ data BaseCommand = Version | Command { mainParams :: MainParams, command :: Comm
 
 main :: IO ()
 main = do
-  cmd <- options "An hledger workflow focusing on automated statement import and classification:\nhttps://github.com/apauley/hledger-flow#readme" baseCommandParser
+  cmd <- Turtle.options "An hledger workflow focusing on automated statement import and classification:\nhttps://github.com/apauley/hledger-flow#readme" baseCommandParser
   case cmd of
-    Version                                -> stdout $ select versionInfo
+    Version                                -> Turtle.stdout $ Turtle.select versionInfo
     Command mainParams' (Import subParams) -> toRuntimeOptionsImport mainParams' subParams >>= importCSVs
     Command mainParams' (Report subParams) -> toRuntimeOptionsReport mainParams' subParams >>= generateReports
 
@@ -73,21 +73,21 @@ baseCommandParser = (Command <$> verboseParser <*> commandParser)
   <|> flag' Version (long "version" <> short 'V' <> help "Display version information")
 
 commandParser :: Parser Command
-commandParser = fmap Import (subcommand "import" "Uses hledger with your own rules and/or scripts to convert electronic statements into categorised journal files" subcommandParserImport)
-  <|> fmap Report (subcommand "report" "Generate Reports" subcommandParserReport)
+commandParser = fmap Import (Turtle.subcommand "import" "Uses hledger with your own rules and/or scripts to convert electronic statements into categorised journal files" subcommandParserImport)
+  <|> fmap Report (Turtle.subcommand "report" "Generate Reports" subcommandParserReport)
 
 verboseParser :: Parser MainParams
 verboseParser = MainParams
   <$> (length <$> many (flag' () (long "verbose" <> short 'v' <> help "Print more verbose output")))
-  <*> optional (optPath "hledger-path" 'H' "The full path to an hledger executable")
+  <*> optional (Turtle.optPath "hledger-path" 'H' "The full path to an hledger executable")
   <*> switch (long "show-options" <> help "Print the options this program will run with")
   <*> switch (long "sequential" <> help "Disable parallel processing")
 
 subcommandParserImport :: Parser ImportParams
 subcommandParserImport = ImportParams
-  <$> optional (argPath "dir" "The directory to import. Use the base directory for a full import or a sub-directory for a partial import. Defaults to the current directory. This behaviour is changing: see --enable-future-rundir")
+  <$> optional (Turtle.argPath "dir" "The directory to import. Use the base directory for a full import or a sub-directory for a partial import. Defaults to the current directory. This behaviour is changing: see --enable-future-rundir")
   <*> switch (long "enable-future-rundir" <> help "Enable the future (0.14.x) default behaviour now: start importing only from the directory that was given as an argument, or the currect directory. Previously a full import was always done. This switch will be removed in 0.14.x")
 
 subcommandParserReport :: Parser ReportParams
 subcommandParserReport = ReportParams
-  <$> optional (argPath "basedir" "The hledger-flow base directory")
+  <$> optional (Turtle.argPath "basedir" "The hledger-flow base directory")

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hledger-flow
-version:             0.13.2.0
+version:             0.14.0.0
 synopsis:            An hledger workflow focusing on automated statement import and classification.
 category:            Finance, Console
 license:             GPL-3
@@ -31,6 +31,9 @@ library:
   - -Wall
   dependencies:
   - turtle
+  - path
+  - path-io
+  - exceptions
   - text
   - foldl
   - containers
@@ -52,6 +55,7 @@ executables:
 
     dependencies:
     - hledger-flow
+    - path
     - turtle
     - text
     - optparse-applicative
@@ -66,6 +70,8 @@ tests:
     - -with-rtsopts=-N
     dependencies:
     - hledger-flow
+    - path
+    - path-io
     - turtle
     - HUnit
     - containers

--- a/src/Hledger/Flow/BaseDir.hs
+++ b/src/Hledger/Flow/BaseDir.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module Hledger.Flow.BaseDir where
+
+import Path
+import Path.IO
+import Hledger.Flow.Types (HasBaseDir, HasRunDir, BaseDir, RunDir, baseDir, importRunDir)
+import Hledger.Flow.PathHelpers
+
+import Data.Maybe
+
+import Control.Monad.Catch (MonadThrow, throwM)
+import Control.Monad.IO.Class (MonadIO)
+
+
+import qualified Turtle as Turtle (stripPrefix)
+
+determineBaseDir :: Maybe TurtlePath -> IO (BaseDir, RunDir)
+determineBaseDir suppliedDir = do
+  pwd <- getCurrentDir
+  determineBaseDir' pwd suppliedDir
+
+determineBaseDir' :: AbsDir -> Maybe TurtlePath -> IO (BaseDir, RunDir)
+determineBaseDir' pwd (Just suppliedDir) = do
+  absDir <- turtleToAbsDir pwd suppliedDir
+  determineBaseDirFromStartDir absDir
+determineBaseDir' pwd Nothing = determineBaseDirFromStartDir pwd
+
+determineBaseDirFromStartDir ::  AbsDir -> IO (BaseDir, RunDir)
+determineBaseDirFromStartDir startDir = determineBaseDirFromStartDir' startDir startDir
+
+determineBaseDirFromStartDir' :: (MonadIO m, MonadThrow m) => AbsDir -> AbsDir -> m (BaseDir, RunDir)
+determineBaseDirFromStartDir' startDir possibleBaseDir = do
+  _ <- if (parent possibleBaseDir == possibleBaseDir) then throwM (MissingBaseDir startDir) else return ()
+  foundBaseDir <- doesDirExist $ possibleBaseDir </> [reldir|import|]
+  if foundBaseDir then
+    do
+      runDir <- makeRelative possibleBaseDir startDir
+      return (possibleBaseDir, runDir)
+    else determineBaseDirFromStartDir' startDir $ parent possibleBaseDir
+
+relativeToBase :: HasBaseDir o => o -> TurtlePath -> TurtlePath
+relativeToBase opts = relativeToBase' $ pathToTurtle (baseDir opts)
+
+relativeToBase' :: TurtlePath -> TurtlePath -> TurtlePath
+relativeToBase' bd p = if forceTrailingSlash bd == forceTrailingSlash p then "./" else
+  fromMaybe p $ Turtle.stripPrefix (forceTrailingSlash bd) p
+
+turtleBaseDir :: HasBaseDir o => o -> TurtlePath
+turtleBaseDir opts = pathToTurtle $ baseDir opts
+
+turtleRunDir :: HasRunDir o => o -> TurtlePath
+turtleRunDir opts = pathToTurtle $ importRunDir opts

--- a/src/Hledger/Flow/BaseDir.hs
+++ b/src/Hledger/Flow/BaseDir.hs
@@ -5,7 +5,7 @@ module Hledger.Flow.BaseDir where
 
 import Path
 import Path.IO
-import Hledger.Flow.Types (HasBaseDir, HasRunDir, BaseDir, RunDir, baseDir, importRunDir)
+import Hledger.Flow.Types (HasBaseDir, BaseDir, RunDir, baseDir)
 import Hledger.Flow.PathHelpers
 
 import Data.Maybe
@@ -50,5 +50,10 @@ relativeToBase' bd p = if forceTrailingSlash bd == forceTrailingSlash p then "./
 turtleBaseDir :: HasBaseDir o => o -> TurtlePath
 turtleBaseDir opts = pathToTurtle $ baseDir opts
 
-turtleRunDir :: HasRunDir o => o -> TurtlePath
-turtleRunDir opts = pathToTurtle $ importRunDir opts
+effectiveRunDir :: BaseDir -> RunDir -> Bool -> AbsDir
+effectiveRunDir bd rd useRunDir = do
+  let baseImportDir = bd </> [Path.reldir|import|]
+  let absRunDir = bd </> rd
+  if useRunDir
+    then if absRunDir == bd then baseImportDir else absRunDir
+    else baseImportDir

--- a/src/Hledger/Flow/CSVImport.hs
+++ b/src/Hledger/Flow/CSVImport.hs
@@ -10,6 +10,9 @@ import qualified Data.Text as T
 import qualified Data.List.NonEmpty as NonEmpty
 import qualified Hledger.Flow.Types as FlowTypes
 import Hledger.Flow.Import.Types
+import Hledger.Flow.BaseDir (turtleBaseDir, turtleRunDir, relativeToBase)
+import Hledger.Flow.PathHelpers (forceTrailingSlash)
+import Hledger.Flow.DocHelpers (docURL)
 import Hledger.Flow.Common
 import Hledger.Flow.RuntimeOptions
 import Control.Concurrent.STM
@@ -35,8 +38,8 @@ inputFilePattern = contains (once (oneOf pathSeparators) <> asciiCI "1-in" <> on
 
 importCSVs' :: RuntimeOptions -> TChan FlowTypes.LogMessage -> IO [FilePath]
 importCSVs' opts ch = do
-  let baseImportDir = forceTrailingSlash $ (baseDir opts) </> "import"
-  let runDir = forceTrailingSlash $ collapse $ (baseDir opts) </> (importRunDir opts)
+  let baseImportDir = forceTrailingSlash $ (turtleBaseDir opts) </> "import"
+  let runDir = forceTrailingSlash $ collapse $ (turtleBaseDir opts) </> (turtleRunDir opts)
   let effectiveDir = if useRunDir opts
         then if (forceTrailingSlash $ runDir </> "import") == baseImportDir then baseImportDir else runDir
         else baseImportDir

--- a/src/Hledger/Flow/DocHelpers.hs
+++ b/src/Hledger/Flow/DocHelpers.hs
@@ -2,8 +2,9 @@
 
 module Hledger.Flow.DocHelpers where
 
-import Data.Text
-import Turtle
+import qualified Data.Text as T (Text)
+import qualified Turtle as Turtle (Line, format, l)
+import Turtle ((%))
 
-docURL :: Line -> Text
-docURL = format ("https://github.com/apauley/hledger-flow#"%l)
+docURL :: Turtle.Line -> T.Text
+docURL = Turtle.format ("https://github.com/apauley/hledger-flow#"%Turtle.l)

--- a/src/Hledger/Flow/DocHelpers.hs
+++ b/src/Hledger/Flow/DocHelpers.hs
@@ -1,0 +1,9 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hledger.Flow.DocHelpers where
+
+import Data.Text
+import Turtle
+
+docURL :: Line -> Text
+docURL = format ("https://github.com/apauley/hledger-flow#"%l)

--- a/src/Hledger/Flow/Import/Types.hs
+++ b/src/Hledger/Flow/Import/Types.hs
@@ -1,13 +1,12 @@
 module Hledger.Flow.Import.Types
 where
 
-import Turtle
-import Prelude hiding (FilePath, putStrLn)
+import Hledger.Flow.PathHelpers (TurtlePath)
 
-data ImportDirs = ImportDirs { importDir  :: FilePath
-                             , ownerDir   :: FilePath
-                             , bankDir    :: FilePath
-                             , accountDir :: FilePath
-                             , stateDir   :: FilePath
-                             , yearDir    :: FilePath
+data ImportDirs = ImportDirs { importDir  :: TurtlePath
+                             , ownerDir   :: TurtlePath
+                             , bankDir    :: TurtlePath
+                             , accountDir :: TurtlePath
+                             , stateDir   :: TurtlePath
+                             , yearDir    :: TurtlePath
                              } deriving (Show)

--- a/src/Hledger/Flow/PathHelpers.hs
+++ b/src/Hledger/Flow/PathHelpers.hs
@@ -1,0 +1,57 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hledger.Flow.PathHelpers where
+
+import Control.Monad.Catch (MonadThrow, Exception, throwM)
+import Control.Monad.IO.Class (MonadIO)
+
+import qualified Data.Text as T
+import qualified Path as Path
+import qualified Path.IO as Path
+import qualified Turtle as Turtle
+
+import Hledger.Flow.DocHelpers (docURL)
+
+type TurtlePath = Turtle.FilePath
+
+type AbsFile = Path.Path Path.Abs Path.File
+type RelFile = Path.Path Path.Rel Path.File
+type AbsDir = Path.Path Path.Abs Path.Dir
+type RelDir = Path.Path Path.Rel Path.Dir
+
+data PathException = MissingBaseDir AbsDir | InvalidTurtleDir TurtlePath
+  deriving (Eq)
+
+instance Show PathException where
+  show (MissingBaseDir d) = "Unable to find an import directory at " ++ show d ++
+    " (or in any of its parent directories).\n\n" ++
+    "Have a look at the documentation for more information:\n" ++
+    T.unpack (docURL "getting-started")
+  show (InvalidTurtleDir  d) = "Expected a directory but got this instead: " ++ Turtle.encodeString d
+
+instance Exception PathException
+
+fromTurtleAbsFile :: MonadThrow m => TurtlePath -> m AbsFile
+fromTurtleAbsFile turtlePath = Path.parseAbsFile $ Turtle.encodeString turtlePath
+
+fromTurtleRelFile :: MonadThrow m => TurtlePath -> m RelFile
+fromTurtleRelFile turtlePath = Path.parseRelFile $ Turtle.encodeString turtlePath
+
+fromTurtleAbsDir :: MonadThrow m => TurtlePath -> m AbsDir
+fromTurtleAbsDir turtlePath = Path.parseAbsDir $ Turtle.encodeString turtlePath
+
+fromTurtleRelDir :: MonadThrow m => TurtlePath -> m RelDir
+fromTurtleRelDir turtlePath = Path.parseRelDir $ Turtle.encodeString turtlePath
+
+turtleToAbsDir :: (MonadIO m, MonadThrow m) => AbsDir -> TurtlePath -> m AbsDir
+turtleToAbsDir baseDir p = do
+  isDir <- Turtle.testdir p
+  if isDir
+    then Path.resolveDir baseDir $ Turtle.encodeString p
+    else throwM $ InvalidTurtleDir p
+
+pathToTurtle :: Path.Path b t -> TurtlePath
+pathToTurtle = Turtle.decodeString . Path.toFilePath
+
+forceTrailingSlash :: TurtlePath -> TurtlePath
+forceTrailingSlash p = Turtle.directory (p Turtle.</> "temp")

--- a/src/Hledger/Flow/Reports.hs
+++ b/src/Hledger/Flow/Reports.hs
@@ -6,8 +6,11 @@ module Hledger.Flow.Reports
 
 import Turtle hiding (stdout, stderr, proc)
 import Prelude hiding (FilePath, putStrLn, writeFile)
+
 import Hledger.Flow.RuntimeOptions
 import Hledger.Flow.Common
+import Hledger.Flow.BaseDir (turtleBaseDir, relativeToBase)
+
 import Control.Concurrent.STM
 import Data.Either
 import Data.Maybe
@@ -46,7 +49,7 @@ generateReports' opts ch = do
   channelOutLn ch wipMsg
   owners <- single $ shellToList $ listOwners opts
   ledgerEnvValue <- need "LEDGER_FILE" :: IO (Maybe Text)
-  let hledgerJournal = fromMaybe (baseDir opts </> allYearsFileName) $ fmap fromText ledgerEnvValue
+  let hledgerJournal = fromMaybe (turtleBaseDir opts </> allYearsFileName) $ fmap fromText ledgerEnvValue
   hledgerJournalExists <- testfile hledgerJournal
   _ <- if not hledgerJournalExists then die $ format ("Unable to find journal file: "%fp%"\nIs your LEDGER_FILE environment variable set correctly?") hledgerJournal else return ()
   let journalWithYears = journalFile opts []
@@ -124,10 +127,10 @@ generateReport opts ch journal baseOutDir year fileName args successCheck = do
       return $ Left outputFile
 
 journalFile :: RuntimeOptions -> [FilePath] -> FilePath
-journalFile opts dirs = (foldl (</>) (baseDir opts) ("import":dirs)) </> allYearsFileName
+journalFile opts dirs = (foldl (</>) (turtleBaseDir opts) ("import":dirs)) </> allYearsFileName
 
 outputReportDir :: RuntimeOptions -> [FilePath] -> FilePath
-outputReportDir opts dirs = foldl (</>) (baseDir opts) ("reports":dirs)
+outputReportDir opts dirs = foldl (</>) (turtleBaseDir opts) ("reports":dirs)
 
 ownerParameters :: RuntimeOptions -> TChan FlowTypes.LogMessage -> [FilePath] -> IO [ReportParams]
 ownerParameters opts ch owners = do

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -2,7 +2,7 @@ module Hledger.Flow.RuntimeOptions
 where
 
 import Turtle
-import Prelude hiding (FilePath, putStrLn)
+import Prelude hiding (putStrLn)
 import Hledger.Flow.Types
 
 data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -5,8 +5,8 @@ import Turtle
 import Prelude hiding (FilePath, putStrLn)
 import Hledger.Flow.Types
 
-data RuntimeOptions = RuntimeOptions { baseDir :: FilePath
-                                     , importRunDir :: FilePath
+data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
+                                     , importRunDir :: RunDir
                                      , useRunDir :: Bool
                                      , hfVersion :: Text
                                      , hledgerInfo :: HledgerInfo
@@ -25,3 +25,6 @@ instance HasSequential RuntimeOptions where
 
 instance HasBaseDir RuntimeOptions where
   baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _) = bd
+
+instance HasRunDir RuntimeOptions where
+  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _) = rd

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -1,14 +1,14 @@
 module Hledger.Flow.RuntimeOptions
 where
 
-import Turtle
+import qualified Data.Text as T
 import Prelude hiding (putStrLn)
 import Hledger.Flow.Types
 
 data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
                                      , importRunDir :: RunDir
                                      , useRunDir :: Bool
-                                     , hfVersion :: Text
+                                     , hfVersion :: T.Text
                                      , hledgerInfo :: HledgerInfo
                                      , sysInfo :: SystemInfo
                                      , verbose :: Bool

--- a/src/Hledger/Flow/Types.hs
+++ b/src/Hledger/Flow/Types.hs
@@ -8,6 +8,11 @@ import Turtle
 import Prelude hiding (FilePath, putStrLn)
 import Data.Version
 
+import Hledger.Flow.PathHelpers
+
+type BaseDir = AbsDir
+type RunDir = RelDir
+
 data LogMessage = StdOut Text | StdErr Text | Terminate deriving (Show)
 type FullOutput = (ExitCode, Text, Text)
 type FullTimedOutput = (FullOutput, NominalDiffTime)
@@ -31,7 +36,10 @@ class HasVerbosity a where
   verbose :: a -> Bool
 
 class HasBaseDir a where
-  baseDir :: a -> FilePath
+  baseDir :: a -> BaseDir
+
+class HasRunDir a where
+  importRunDir :: a -> RunDir
 
 class HasSequential a where
   sequential :: a -> Bool

--- a/src/Hledger/Flow/Types.hs
+++ b/src/Hledger/Flow/Types.hs
@@ -5,7 +5,6 @@ module Hledger.Flow.Types
 where
 
 import Turtle
-import Prelude hiding (FilePath, putStrLn)
 import Data.Version
 
 import Hledger.Flow.PathHelpers
@@ -20,7 +19,7 @@ type FullTimedOutput = (FullOutput, NominalDiffTime)
 type ProcFun = Text -> [Text] -> Shell Line -> IO FullOutput
 type ProcInput = (Text, [Text], Shell Line)
 
-data HledgerInfo = HledgerInfo { hlPath :: FilePath
+data HledgerInfo = HledgerInfo { hlPath :: TurtlePath
                                , hlVersion :: Text
                                }
                  deriving (Show)

--- a/src/Hledger/Flow/Types.hs
+++ b/src/Hledger/Flow/Types.hs
@@ -4,7 +4,8 @@
 module Hledger.Flow.Types
 where
 
-import Turtle
+import qualified Turtle as Turtle (ExitCode, NominalDiffTime, Shell, Line)
+import qualified Data.Text as T
 import Data.Version
 
 import Hledger.Flow.PathHelpers
@@ -12,15 +13,15 @@ import Hledger.Flow.PathHelpers
 type BaseDir = AbsDir
 type RunDir = RelDir
 
-data LogMessage = StdOut Text | StdErr Text | Terminate deriving (Show)
-type FullOutput = (ExitCode, Text, Text)
-type FullTimedOutput = (FullOutput, NominalDiffTime)
+data LogMessage = StdOut T.Text | StdErr T.Text | Terminate deriving (Show)
+type FullOutput = (Turtle.ExitCode, T.Text, T.Text)
+type FullTimedOutput = (FullOutput, Turtle.NominalDiffTime)
 
-type ProcFun = Text -> [Text] -> Shell Line -> IO FullOutput
-type ProcInput = (Text, [Text], Shell Line)
+type ProcFun = T.Text -> [T.Text] -> Turtle.Shell Turtle.Line -> IO FullOutput
+type ProcInput = (T.Text, [T.Text], Turtle.Shell Turtle.Line)
 
 data HledgerInfo = HledgerInfo { hlPath :: TurtlePath
-                               , hlVersion :: Text
+                               , hlVersion :: T.Text
                                }
                  deriving (Show)
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2020-03-10
+resolver: nightly-2020-08-10
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2020-08-10
+resolver: nightly-2020-08-27
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 501929
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/3/10.yaml
-    sha256: b85b932144210a13f4628768d3e7f40bf2071ab0acf932671ff1aadac390d566
-  original: nightly-2020-03-10
+    size: 520653
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/8/10.yaml
+    sha256: 2e0c7e242a3b8cbc6f9027f03c7aeaa5609c82bcc40e2b00b7fa9c4d1269ddcd
+  original: nightly-2020-08-10

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 520653
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/8/10.yaml
-    sha256: 2e0c7e242a3b8cbc6f9027f03c7aeaa5609c82bcc40e2b00b7fa9c4d1269ddcd
-  original: nightly-2020-08-10
+    size: 523649
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/8/27.yaml
+    sha256: 95012648db1b2180e3d7e0a3d44bc2a61b6854028382674724fee7ffa24300c3
+  original: nightly-2020-08-27

--- a/test/BaseDir/Integration.hs
+++ b/test/BaseDir/Integration.hs
@@ -1,0 +1,122 @@
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
+
+module BaseDir.Integration (tests) where
+
+import Control.Exception (try)
+import Test.HUnit
+
+import Path
+import Path.IO
+import Prelude hiding (FilePath)
+
+import qualified Turtle as Turtle
+import qualified Data.Text as T
+
+import Hledger.Flow.Common
+import Hledger.Flow.Types (BaseDir, RunDir)
+import Hledger.Flow.BaseDir (determineBaseDir)
+import Hledger.Flow.PathHelpers
+
+assertSubDirsForDetermineBaseDir :: AbsDir -> BaseDir -> [Path.Path b Dir] -> IO ()
+assertSubDirsForDetermineBaseDir initialPwd expectedBaseDir importDirs = do
+  _ <- sequence $ map (assertDetermineBaseDir initialPwd expectedBaseDir) importDirs
+  return ()
+
+assertDetermineBaseDir :: AbsDir -> BaseDir -> Path.Path b Dir -> IO ()
+assertDetermineBaseDir initialPwd expectedBaseDir subDir = do
+  setCurrentDir initialPwd
+  (bd1, runDir1) <- determineBaseDir $ Just $ pathToTurtle subDir
+  assertFindTestFileUsingRundir bd1 runDir1
+
+  setCurrentDir subDir
+  (bd2, runDir2) <- determineBaseDir Nothing
+  assertFindTestFileUsingRundir bd2 runDir2
+
+  (bd3, runDir3) <- determineBaseDir $ Just "."
+  assertFindTestFileUsingRundir bd3 runDir3
+
+  (bd4, runDir4) <- determineBaseDir $ Just "./"
+  assertFindTestFileUsingRundir bd4 runDir4
+
+  setCurrentDir initialPwd
+  let msg dir = "determineBaseDir searches from pwd upwards until it finds a dir containing 'import' - " ++ (show dir)
+  _ <- sequence $ map (\dir -> assertEqual (msg dir) expectedBaseDir dir) [bd1, bd2, bd3, bd4]
+  return ()
+
+assertFindTestFileUsingRundir :: BaseDir -> RunDir -> IO ()
+assertFindTestFileUsingRundir baseDir runDir = do
+  let absRunDir = baseDir </> runDir
+
+  found <- Turtle.single $ fmap head $ shellToList $ Turtle.find (Turtle.has "test-file.txt") $ pathToTurtle absRunDir
+  fileContents <- Turtle.readTextFile found
+  assertEqual "We should find our test file by searching from the returned runDir" (T.pack $ "The expected base dir is " ++ show baseDir) fileContents
+
+assertCurrentDirVariations :: AbsDir -> RelDir -> IO ()
+assertCurrentDirVariations absoluteTempDir bdRelativeToTempDir = do
+  let absBaseDir = absoluteTempDir </> bdRelativeToTempDir
+
+  setCurrentDir absBaseDir
+  (bd1, runDir1) <- determineBaseDir Nothing
+  (bd2, runDir2) <- determineBaseDir $ Just "."
+  (bd3, runDir3) <- determineBaseDir $ Just "./"
+  (bd4, runDir4) <- determineBaseDir $ Just $ pathToTurtle absBaseDir
+
+  let msg label dir = "When pwd is the base dir, determineBaseDir returns the same " ++ label ++ ", regardless of the input variation. " ++ (show dir)
+  _ <- sequence $ map (\dir -> assertEqual (msg "baseDir" dir) absBaseDir dir) [bd1, bd2, bd3, bd4]
+  _ <- sequence $ map (\dir -> assertEqual (msg "runDir" dir) [reldir|.|] dir) [runDir1, runDir2, runDir3, runDir4]
+  return ()
+
+testBaseDirWithTempDir :: AbsDir -> AbsDir -> IO ()
+testBaseDirWithTempDir initialPwd absoluteTempDir = do
+  error1 <- try $ determineBaseDir $ Just "/path/to/dir"
+  assertEqual "determineBaseDir produces an error message when given a non-existant dir" (Left $ InvalidTurtleDir "/path/to/dir") error1
+
+  let unrelatedDir = absoluteTempDir </> [reldir|unrelated|]
+  createDir unrelatedDir
+
+  bdUnrelated <- try $ determineBaseDir $ Just (pathToTurtle unrelatedDir)
+  assertEqual "determineBaseDir produces an error message when it cannot find a baseDir" (Left $ MissingBaseDir unrelatedDir) bdUnrelated
+
+  let baseDir = [reldir|bd1|]
+  let importDir = baseDir </> [reldir|import|]
+  let ownerDir = importDir </> [reldir|john|]
+  let bankDir = ownerDir </> [reldir|mybank|]
+  let accDir = bankDir </> [reldir|myacc|]
+  let inDir = accDir </> [reldir|1-in|]
+  let yearDir = inDir </> [reldir|2019|]
+  let subDirs = [yearDir, inDir, accDir, bankDir, ownerDir, importDir, baseDir] :: [RelDir]
+
+  createDirIfMissing True $ absoluteTempDir </> yearDir
+
+  let fictionalDir = absoluteTempDir </> ownerDir </> [reldir|fictionalDir|]
+  errorSub <- try $ determineBaseDir $ Just $ pathToTurtle fictionalDir
+  assertEqual "determineBaseDir produces an error message when given a non-existant subdir of a valid basedir" (Left $ InvalidTurtleDir $ pathToTurtle fictionalDir) errorSub
+
+  assertCurrentDirVariations absoluteTempDir baseDir
+
+  relativeTempDir <- makeRelative initialPwd absoluteTempDir
+  let subDirsRelativeToTop = map (relativeTempDir </>) subDirs
+  let absoluteSubDirs = map (absoluteTempDir </>) subDirs
+
+  let absoluteBaseDir = absoluteTempDir </> baseDir
+
+  Turtle.writeTextFile (pathToTurtle $ absoluteTempDir </> yearDir </> [relfile|test-file.txt|]) (T.pack $ "The expected base dir is " ++ show absoluteBaseDir)
+
+  assertSubDirsForDetermineBaseDir absoluteTempDir absoluteBaseDir subDirs
+  assertSubDirsForDetermineBaseDir absoluteTempDir absoluteBaseDir absoluteSubDirs
+  assertSubDirsForDetermineBaseDir initialPwd absoluteBaseDir subDirsRelativeToTop
+  return ()
+
+testDetermineBaseDir :: Test
+testDetermineBaseDir = TestCase (
+  do
+    initialPwd <- getCurrentDir
+    let tmpbase = initialPwd </> [reldir|test|] </> [reldir|tmp|]
+    createDirIfMissing True tmpbase
+    withTempDir tmpbase "hlflowtest" $ testBaseDirWithTempDir initialPwd
+  )
+
+tests :: Test
+tests = TestList [testDetermineBaseDir]

--- a/test/BaseDir/Integration.hs
+++ b/test/BaseDir/Integration.hs
@@ -9,7 +9,6 @@ import Test.HUnit
 
 import Path
 import Path.IO
-import Prelude hiding (FilePath)
 
 import qualified Turtle as Turtle
 import qualified Data.Text as T

--- a/test/CSVImport/Integration.hs
+++ b/test/CSVImport/Integration.hs
@@ -5,7 +5,6 @@ module CSVImport.Integration (tests) where
 
 import Test.HUnit
 import Turtle
-import Prelude hiding (FilePath)
 import qualified Data.Map.Strict as Map
 import qualified Data.List as List (sort)
 
@@ -22,11 +21,11 @@ testExtraIncludesForFile = TestCase (
         tmpdir <- using (mktempdir currentDir "hlflow")
         tmpdirAbsPath <- fromTurtleAbsDir tmpdir
 
-        let importedJournals = map (tmpdir </>) journalFiles :: [FilePath]
+        let importedJournals = map (tmpdir </>) journalFiles :: [TurtlePath]
         let accountDir = "import/john/bogartbank/savings"
         let opening = tmpdir </> accountDir </> "2017-opening.journal"
         let closing = tmpdir </> accountDir </> "2017-closing.journal"
-        let hidden = map (tmpdir </>) hiddenFiles :: [FilePath]
+        let hidden = map (tmpdir </>) hiddenFiles :: [TurtlePath]
         touchAll $ importedJournals ++ hidden
 
         let accountInclude = tmpdir </> accountDir </> "2017-include.journal"
@@ -57,7 +56,7 @@ testExtraIncludesPrices = TestCase (
         tmpdir <- using (mktempdir currentDir "hlflow")
         tmpdirAbsPath <- fromTurtleAbsDir tmpdir
 
-        let importedJournals = map (tmpdir </>) journalFiles :: [FilePath]
+        let importedJournals = map (tmpdir </>) journalFiles :: [TurtlePath]
         touchAll $ importedJournals
 
         let priceFile = "prices" </> "2020" </> "prices.journal"
@@ -168,9 +167,9 @@ testWriteIncludeFiles = TestCase (
         tmpdir <- using (mktempdir currentDir "hlflow")
         tmpdirAbsPath <- fromTurtleAbsDir tmpdir
 
-        let importedJournals = map (tmpdir </>) journalFiles :: [FilePath]
-        let extras = map (tmpdir </>) extraFiles :: [FilePath]
-        let hidden = map (tmpdir </>) hiddenFiles :: [FilePath]
+        let importedJournals = map (tmpdir </>) journalFiles :: [TurtlePath]
+        let extras = map (tmpdir </>) extraFiles :: [TurtlePath]
+        let hidden = map (tmpdir </>) hiddenFiles :: [TurtlePath]
         touchAll $ importedJournals ++ extras ++ hidden
 
         let jane1 = tmpdir </> "import/jane/bogartbank/checking/2018-include.journal"

--- a/test/CSVImport/Unit.hs
+++ b/test/CSVImport/Unit.hs
@@ -7,17 +7,17 @@ module CSVImport.Unit where
 import Test.HUnit
 import Path
 import Turtle
-import Prelude hiding (FilePath)
 import qualified Data.Map.Strict as Map
 import Control.Concurrent.STM
 
 import TestHelpers
+import Hledger.Flow.PathHelpers (TurtlePath)
 import Hledger.Flow.Common
 
 import Data.Either
 import qualified Data.Text as T
 
-groupedJaneBogart :: Map.Map FilePath [FilePath]
+groupedJaneBogart :: Map.Map TurtlePath [TurtlePath]
 groupedJaneBogart = [
   ("./import/jane/bogartbank/checking/2018-include.journal",
    ["import/jane/bogartbank/checking/3-journal/2018/2018-12-30.journal"]),
@@ -28,7 +28,7 @@ groupedJaneBogart = [
   ("./import/jane/bogartbank/savings/2018-include.journal",
    ["import/jane/bogartbank/savings/3-journal/2018/2018-01-30.journal"])]
 
-groupedJaneOther :: Map.Map FilePath [FilePath]
+groupedJaneOther :: Map.Map TurtlePath [TurtlePath]
 groupedJaneOther = [
   ("./import/jane/otherbank/creditcard/2017-include.journal",
    ["import/jane/otherbank/creditcard/3-journal/2017/2017-12-30.journal"]),
@@ -39,7 +39,7 @@ groupedJaneOther = [
   ("./import/jane/otherbank/investments/2019-include.journal",
    ["import/jane/otherbank/investments/3-journal/2019/2019-01-30.journal"])]
 
-groupedJohnBogart :: Map.Map FilePath [FilePath]
+groupedJohnBogart :: Map.Map TurtlePath [TurtlePath]
 groupedJohnBogart = [
   ("./import/john/bogartbank/checking/2018-include.journal",
    ["import/john/bogartbank/checking/3-journal/2018/2018-11-30.journal",
@@ -55,7 +55,7 @@ groupedJohnBogart = [
    ["import/john/bogartbank/savings/3-journal/2018/2018-02-30.journal",
     "import/john/bogartbank/savings/3-journal/2018/2018-01-30.journal"])]
 
-groupedJohnOther :: Map.Map FilePath [FilePath]
+groupedJohnOther :: Map.Map TurtlePath [TurtlePath]
 groupedJohnOther = [
   ("./import/john/otherbank/creditcard/2017-include.journal",
    ["import/john/otherbank/creditcard/3-journal/2017/2017-12-30.journal"]),
@@ -66,7 +66,7 @@ groupedJohnOther = [
   ("./import/john/otherbank/investments/2019-include.journal",
    ["import/john/otherbank/investments/3-journal/2019/2019-01-30.journal"])]
 
-groupedIncludeFiles :: Map.Map FilePath [FilePath]
+groupedIncludeFiles :: Map.Map TurtlePath [TurtlePath]
 groupedIncludeFiles = groupedJaneBogart <> groupedJaneOther <>
                       groupedJohnBogart <> groupedJohnOther
 
@@ -101,21 +101,21 @@ testGroupIncludeFilesTinySet :: Test
 testGroupIncludeFilesTinySet = TestCase (
   do
     let journals1 = [   "import/jane/bogartbank/savings/3-journals/2017/2017-12-30.journal"]
-    let expected1 = [("./import/jane/bogartbank/savings/2017-include.journal", journals1)] :: Map.Map FilePath [FilePath]
+    let expected1 = [("./import/jane/bogartbank/savings/2017-include.journal", journals1)] :: Map.Map TurtlePath [TurtlePath]
     let expectedAllYears1 = [("./import/jane/bogartbank/savings/all-years.journal", ["./import/jane/bogartbank/savings/2017-include.journal"])]
     let (group1, allYears1) = groupIncludeFiles journals1
     assertEqual "groupIncludeFiles small allYears 1" expectedAllYears1 allYears1
     assertEqual "groupIncludeFiles small set 1" expected1 group1
 
-    let journals2 = [(fst . head . Map.toList) expected1] :: [FilePath]
-    let expected2 = [("./import/jane/bogartbank/2017-include.journal", journals2)] :: Map.Map FilePath [FilePath]
+    let journals2 = [(fst . head . Map.toList) expected1] :: [TurtlePath]
+    let expected2 = [("./import/jane/bogartbank/2017-include.journal", journals2)] :: Map.Map TurtlePath [TurtlePath]
     let expectedAllYears2 = [("./import/jane/bogartbank/all-years.journal", ["./import/jane/bogartbank/2017-include.journal"])]
     let (group2, allYears2) = groupIncludeFiles journals2
     assertEqual "groupIncludeFiles small allYears 2" expectedAllYears2 allYears2
     assertEqual "groupIncludeFiles small set 2" expected2 group2
 
-    let journals3 = [(fst . head . Map.toList) expected2] :: [FilePath]
-    let expected3 = [("./import/jane/2017-include.journal", journals3)] :: Map.Map FilePath [FilePath]
+    let journals3 = [(fst . head . Map.toList) expected2] :: [TurtlePath]
+    let expected3 = [("./import/jane/2017-include.journal", journals3)] :: Map.Map TurtlePath [TurtlePath]
     let expectedAllYears3 = [("./import/jane/all-years.journal", ["./import/jane/2017-include.journal"])]
     let (group3, allYears3) = groupIncludeFiles journals3
     assertEqual "groupIncludeFiles small allYears 3" expectedAllYears3 allYears3

--- a/test/CSVImport/Unit.hs
+++ b/test/CSVImport/Unit.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module CSVImport.Unit where
 
 import Test.HUnit
+import Path
 import Turtle
 import Prelude hiding (FilePath)
 import qualified Data.Map.Strict as Map
@@ -420,7 +422,7 @@ testToIncludeFiles = TestCase (
            "!include import/john/bogartbank/savings/3-journal/2018/2018-02-30.journal\n")]
 
     ch <- newTChanIO
-    txt <- toIncludeFiles (defaultOpts ".") ch groupedJohnBogart
+    txt <- toIncludeFiles (defaultOpts [absdir|/|]) ch groupedJohnBogart
     assertEqual "Convert a grouped map of paths, to a map with text contents for each file" expected txt)
 
 tests :: Test

--- a/test/Common/Integration.hs
+++ b/test/Common/Integration.hs
@@ -5,10 +5,10 @@ module Common.Integration (tests) where
 
 import Test.HUnit
 import Turtle
-import Prelude hiding (FilePath)
 import qualified Data.List as List (sort)
 
 import TestHelpers
+import Hledger.Flow.PathHelpers (TurtlePath)
 import Hledger.Flow.Common
 
 testHiddenFiles :: Test
@@ -18,9 +18,9 @@ testHiddenFiles = TestCase (
         let tmpbase = "." </> "test" </> "tmp"
         mktree tmpbase
         tmpdir <- using (mktempdir tmpbase "hlflowtest")
-        let tmpJournals = map (tmpdir </>) journalFiles :: [FilePath]
-        let tmpExtras = map (tmpdir </>) extraFiles :: [FilePath]
-        let tmpHidden = map (tmpdir </>) hiddenFiles :: [FilePath]
+        let tmpJournals = map (tmpdir </>) journalFiles :: [TurtlePath]
+        let tmpExtras = map (tmpdir </>) extraFiles :: [TurtlePath]
+        let tmpHidden = map (tmpdir </>) hiddenFiles :: [TurtlePath]
         let onDisk = List.sort $ tmpJournals ++ tmpExtras ++ tmpHidden
         touchAll onDisk
         filtered <- (fmap List.sort) $ shellToList $ onlyFiles $ select onDisk
@@ -36,9 +36,9 @@ testFilterPaths = TestCase (
         let tmpbase = "." </> "test" </> "tmp"
         mktree tmpbase
         tmpdir <- using (mktempdir tmpbase "hlflowtest")
-        let tmpJournals = map (tmpdir </>) journalFiles :: [FilePath]
-        let tmpExtras = map (tmpdir </>) extraFiles :: [FilePath]
-        let tmpHidden = map (tmpdir </>) hiddenFiles :: [FilePath]
+        let tmpJournals = map (tmpdir </>) journalFiles :: [TurtlePath]
+        let tmpExtras = map (tmpdir </>) extraFiles :: [TurtlePath]
+        let tmpHidden = map (tmpdir </>) hiddenFiles :: [TurtlePath]
         let onDisk = List.sort $ tmpJournals ++ tmpExtras ++ tmpHidden
         touchAll onDisk
 

--- a/test/Common/Integration.hs
+++ b/test/Common/Integration.hs
@@ -7,7 +7,6 @@ import Test.HUnit
 import Turtle
 import Prelude hiding (FilePath)
 import qualified Data.List as List (sort)
-import qualified Data.Text as T
 
 import TestHelpers
 import Hledger.Flow.Common
@@ -27,113 +26,6 @@ testHiddenFiles = TestCase (
         filtered <- (fmap List.sort) $ shellToList $ onlyFiles $ select onDisk
         let expected = List.sort $ tmpExtras ++ tmpJournals
         liftIO $ assertEqual "Hidden files should be excluded" expected filtered
-     )
-  )
-
-assertSubDirsForDetermineBaseDir :: FilePath -> FilePath -> [FilePath] -> IO ()
-assertSubDirsForDetermineBaseDir initialPwd expectedBaseDir importDirs = do
-  _ <- sequence $ map (assertDetermineBaseDir initialPwd expectedBaseDir) importDirs
-  return ()
-
-assertDetermineBaseDir :: FilePath -> FilePath -> FilePath -> IO ()
-assertDetermineBaseDir initialPwd expectedBaseDir subDir = do
-  cd initialPwd
-  (bd1, runDir1) <- determineBaseDir $ Just subDir
-  assertFindTestFileUsingRundir bd1 runDir1
-
-  cd subDir
-  (bd2, runDir2) <- determineBaseDir Nothing
-  assertFindTestFileUsingRundir bd2 runDir2
-
-  (bd3, runDir3) <- determineBaseDir $ Just "."
-  assertFindTestFileUsingRundir bd3 runDir3
-
-  (bd4, runDir4) <- determineBaseDir $ Just "./"
-  assertFindTestFileUsingRundir bd4 runDir4
-
-  cd initialPwd
-  let msg = format ("determineBaseDir searches from pwd upwards until it finds a dir containing 'import' - "%fp) subDir
-  _ <- sequence $ map (assertEqual (T.unpack msg) expectedBaseDir) [bd1, bd2, bd3, bd4]
-  return ()
-
-assertFindTestFileUsingRundir :: FilePath -> FilePath -> IO ()
-assertFindTestFileUsingRundir baseDir runDir = do
-  let absRunDir = baseDir </> runDir
-  let dirTestMsg = format ("Directories should end with a slash: "%fp)
-  _ <- sequence $ map (\dir -> assertEqual (T.unpack $ dirTestMsg dir) (forceTrailingSlash dir) dir) [baseDir, runDir, absRunDir]
-
-  found <- single $ fmap head $ shellToList $ find (has "test-file.txt") absRunDir
-  fileContents <- readTextFile found
-  assertEqual "We should find our test file by searching from the returned runDir" (format ("The expected base dir is "%fp) baseDir) fileContents
-
-assertCurrentDirVariations :: FilePath -> FilePath -> IO ()
-assertCurrentDirVariations absoluteTempDir bdRelativeToTempDir = do
-  let absBaseDirNoTrailingSlash = absoluteTempDir </> bdRelativeToTempDir
-  let absBaseDirWithTrailingSlash = forceTrailingSlash absBaseDirNoTrailingSlash
-  assertEqual "Test the test: with and without slashes should really be that" '/' (T.last $ format fp absBaseDirWithTrailingSlash)
-  assertBool "Test the test: with and without slashes should really be that" ('/' /= (T.last $ format fp absBaseDirNoTrailingSlash))
-
-  cd absBaseDirNoTrailingSlash
-  (bd1, runDir1) <- liftIO $ determineBaseDir Nothing
-  (bd2, runDir2) <- liftIO $ determineBaseDir $ Just "."
-  (bd3, runDir3) <- liftIO $ determineBaseDir $ Just "./"
-  (bd4, runDir4) <- liftIO $ determineBaseDir $ Just absBaseDirNoTrailingSlash
-  (bd5, runDir5) <- liftIO $ determineBaseDir $ Just absBaseDirWithTrailingSlash
-
-  let msg label dir = format ("When pwd is the base dir, determineBaseDir returns the same "%s%", regardless of the input variation. "%s%":  "%fp) label label dir
-  _ <- sequence $ map (\dir -> assertEqual (T.unpack $ msg "baseDir" dir) (forceTrailingSlash dir) dir) [bd1, bd2, bd3, bd4,bd5]
-  _ <- sequence $ map (\dir -> assertEqual (T.unpack $ msg "runDir" dir) "./" dir) [runDir1, runDir2, runDir3, runDir4, runDir5]
-  -- _ <- sequence $ map (\dir -> assertEqual (T.unpack $ msg "runDir" dir) "./" dir) [runDir2, runDir3, runDir4, runDir5]
-  return ()
-
-testDetermineBaseDir :: Test
-testDetermineBaseDir = TestCase (
-  sh (
-      do
-        error1 <- liftIO $ determineBaseDirFromAbsoluteStartDir "/path/to/dir"
-        liftIO $ assertEqual "determineBaseDir produces an error message when given a non-existant dir" (Left "The provided directory does not exist: /path/to/dir") error1
-
-        initialPwd <- fmap forceTrailingSlash pwd
-        let tmpbase = initialPwd </> "test" </> "tmp"
-        mktree tmpbase
-        absoluteTempDir <- fmap forceTrailingSlash $ using (mktempdir tmpbase "hlflowtest")
-
-        let unrelatedDir = absoluteTempDir </> "unrelated"
-        mkdir unrelatedDir
-
-        bdUnrelated <- liftIO $ determineBaseDirFromAbsoluteStartDir unrelatedDir
-        liftIO $ assertEqual "determineBaseDir produces an error message when it cannot find a baseDir" (Left $ errorMessageBaseDir unrelatedDir) bdUnrelated
-
-        let baseDir = "bd1"
-        let importDir = baseDir </> "import"
-        let ownerDir = importDir </> "john"
-        let bankDir = ownerDir </> "mybank"
-        let accDir = bankDir </> "myacc"
-        let inDir = accDir </> "1-in"
-        let yearDir = inDir </> "2019"
-        let subDirs = [yearDir, inDir, accDir, bankDir, ownerDir, importDir, baseDir]
-
-        mktree $ absoluteTempDir </> yearDir
-
-        let fictionalDir = absoluteTempDir </> ownerDir </> "fictionalDir"
-        errorSub <- liftIO $ determineBaseDirFromAbsoluteStartDir fictionalDir
-        liftIO $ assertEqual "determineBaseDir produces an error message when given a non-existant subdir of a valid basedir" (Left $ format ("The provided directory does not exist: "%fp) fictionalDir) errorSub
-
-        let relativeTempDir = foldl1 mappend (dropWhile (\el -> el `elem` (splitDirectories initialPwd)) (splitDirectories absoluteTempDir))
-
-
-        let subDirsRelativeToTop = map (relativeTempDir </>) subDirs
-        let absoluteSubDirs = map (absoluteTempDir </>) subDirs
-
-        let absoluteBaseDir = forceTrailingSlash $ absoluteTempDir </> baseDir
-
-        liftIO $ assertCurrentDirVariations absoluteTempDir baseDir
-
-        liftIO $ writeTextFile (absoluteTempDir </> yearDir </> "test-file.txt") $ format ("The expected base dir is "%fp) absoluteBaseDir
-
-        liftIO $ assertSubDirsForDetermineBaseDir absoluteTempDir absoluteBaseDir subDirs
-        liftIO $ assertSubDirsForDetermineBaseDir absoluteTempDir absoluteBaseDir absoluteSubDirs
-        liftIO $ assertSubDirsForDetermineBaseDir initialPwd absoluteBaseDir subDirsRelativeToTop
      )
   )
 
@@ -159,4 +51,4 @@ testFilterPaths = TestCase (
   )
 
 tests :: Test
-tests = TestList [testDetermineBaseDir, testHiddenFiles, testFilterPaths]
+tests = TestList [testHiddenFiles, testFilterPaths]

--- a/test/Common/Unit.hs
+++ b/test/Common/Unit.hs
@@ -4,7 +4,6 @@
 module Common.Unit where
 
 import Test.HUnit
-import Prelude hiding (FilePath)
 
 import Hledger.Flow.BaseDir (relativeToBase')
 import Hledger.Flow.Common

--- a/test/Common/Unit.hs
+++ b/test/Common/Unit.hs
@@ -6,6 +6,7 @@ module Common.Unit where
 import Test.HUnit
 import Prelude hiding (FilePath)
 
+import Hledger.Flow.BaseDir (relativeToBase')
 import Hledger.Flow.Common
 
 testShowCmdArgs :: Test

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -5,7 +5,6 @@ module Main where
 
 import Test.HUnit
 import Turtle
-import Prelude hiding (FilePath)
 
 import qualified Common.Unit
 import qualified Common.Integration

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -9,11 +9,12 @@ import Prelude hiding (FilePath)
 
 import qualified Common.Unit
 import qualified Common.Integration
+import qualified BaseDir.Integration
 import qualified CSVImport.Unit
 import qualified CSVImport.Integration
 
 tests :: Test
-tests = TestList [Common.Unit.tests, Common.Integration.tests, CSVImport.Unit.tests, CSVImport.Integration.tests]
+tests = TestList [Common.Unit.tests, Common.Integration.tests, BaseDir.Integration.tests, CSVImport.Unit.tests, CSVImport.Integration.tests]
 
 main :: IO Counts
 main = do

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -6,13 +6,13 @@ module TestHelpers where
 
 import Path
 import Turtle
-import Prelude hiding (FilePath)
 
 import qualified Hledger.Flow.Types as FlowTypes
+import Hledger.Flow.PathHelpers (TurtlePath)
 import Hledger.Flow.Common
 import Hledger.Flow.RuntimeOptions
 
-inputJohnBogart :: [FilePath]
+inputJohnBogart :: [TurtlePath]
 inputJohnBogart = [
   "import/john/bogartbank/savings/1-in/2017/2017-11-30.csv",
   "import/john/bogartbank/savings/1-in/2017/2017-12-30.csv",
@@ -24,37 +24,37 @@ inputJohnBogart = [
   "import/john/bogartbank/checking/1-in/2019/2019-01-30.csv",
   "import/john/bogartbank/checking/1-in/2019/2019-02-30.csv"]
 
-inputJohnOther :: [FilePath]
+inputJohnOther :: [TurtlePath]
 inputJohnOther = [
   "import/john/otherbank/creditcard/1-in/2017/2017-12-30.csv",
   "import/john/otherbank/creditcard/1-in/2018/2018-01-30.csv",
   "import/john/otherbank/investments/1-in/2018/2018-12-30.csv",
   "import/john/otherbank/investments/1-in/2019/2019-01-30.csv"]
 
-inputJaneBogart :: [FilePath]
+inputJaneBogart :: [TurtlePath]
 inputJaneBogart = [
   "import/jane/bogartbank/savings/1-in/2017/2017-12-30.csv",
   "import/jane/bogartbank/savings/1-in/2018/2018-01-30.csv",
   "import/jane/bogartbank/checking/1-in/2018/2018-12-30.csv",
   "import/jane/bogartbank/checking/1-in/2019/2019-01-30.csv"]
 
-inputJaneOther :: [FilePath]
+inputJaneOther :: [TurtlePath]
 inputJaneOther = [
   "import/jane/otherbank/creditcard/1-in/2017/2017-12-30.csv",
   "import/jane/otherbank/creditcard/1-in/2018/2018-01-30.csv",
   "import/jane/otherbank/investments/1-in/2018/2018-12-30.csv",
   "import/jane/otherbank/investments/1-in/2019/2019-01-30.csv"]
 
-inputFiles :: [FilePath]
+inputFiles :: [TurtlePath]
 inputFiles = inputJohnBogart <> inputJohnOther <> inputJaneBogart <> inputJaneOther
 
-journalFiles :: [FilePath]
+journalFiles :: [TurtlePath]
 journalFiles = toJournals inputFiles
 
-extraFiles :: [FilePath]
+extraFiles :: [TurtlePath]
 extraFiles = ["import/john/bogartbank/savings/2017-opening.journal"]
 
-hiddenFiles :: [FilePath]
+hiddenFiles :: [TurtlePath]
 hiddenFiles = [".hiddenfile", "checking/.DS_Store", "import/john/bogartbank/savings/1-in/.anotherhiddenfile", "import/john/bogartbank/checking/1-in/2018/.hidden"]
 
 defaultHlInfo :: FlowTypes.HledgerInfo
@@ -63,13 +63,13 @@ defaultHlInfo = FlowTypes.HledgerInfo "/path/to/hledger" "1.2.3"
 defaultOpts :: FlowTypes.BaseDir -> RuntimeOptions
 defaultOpts bd = RuntimeOptions bd [reldir|./|] True versionInfo' defaultHlInfo systemInfo False False False
 
-toJournals :: [FilePath] -> [FilePath]
+toJournals :: [TurtlePath] -> [TurtlePath]
 toJournals = map (changePathAndExtension "3-journal" "journal")
 
-touchAll :: [FilePath] -> Shell ()
+touchAll :: [TurtlePath] -> Shell ()
 touchAll = foldl (\acc file -> acc <> superTouch file) (return ())
 
-superTouch :: FilePath -> Shell ()
+superTouch :: TurtlePath -> Shell ()
 superTouch file = do
   mktree $ directory file
   touch file

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -1,8 +1,10 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedLists #-}
+{-# LANGUAGE QuasiQuotes #-}
 
 module TestHelpers where
 
+import Path
 import Turtle
 import Prelude hiding (FilePath)
 
@@ -58,8 +60,8 @@ hiddenFiles = [".hiddenfile", "checking/.DS_Store", "import/john/bogartbank/savi
 defaultHlInfo :: FlowTypes.HledgerInfo
 defaultHlInfo = FlowTypes.HledgerInfo "/path/to/hledger" "1.2.3"
 
-defaultOpts :: FilePath -> RuntimeOptions
-defaultOpts bd = RuntimeOptions bd "./" True versionInfo' defaultHlInfo systemInfo False False False
+defaultOpts :: FlowTypes.BaseDir -> RuntimeOptions
+defaultOpts bd = RuntimeOptions bd [reldir|./|] True versionInfo' defaultHlInfo systemInfo False False False
 
 toJournals :: [FilePath] -> [FilePath]
 toJournals = map (changePathAndExtension "3-journal" "journal")


### PR DESCRIPTION
hledger-flow started as a collection of bash scripts that I translated into Haskell with the help of [Turtle](https://hackage.haskell.org/package/turtle).

Turtle uses the now deprecated [system-filepath](https://hackage.haskell.org/package/system-filepath) to represent all paths.

I've had many filepath-related issues in hledger-flow.
They were related to issues such as that 2 instances of the same directory would not be treated as equal, because one could have a trailing slash and the other not.
Another issue that popped up was knowing wether a path is a file or a directory, and if it is absolute or relative.

All of these issues are articulated in the `path` library:
https://github.com/commercialhaskell/path

This PR switches some usages of `system-filepath` over to [path](https://github.com/commercialhaskell/path)
