### PR TITLE
Add --new-files-only as an import option

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -17,7 +17,9 @@ import Hledger.Flow.Reports
 import Hledger.Flow.CSVImport
 
 data ImportParams = ImportParams { maybeImportBaseDir :: Maybe TurtlePath
-                                 , importUseRunDir :: Bool } deriving (Show)
+                                 , importUseRunDir :: Bool
+                                 , onlyNewFiles :: Bool
+                                 } deriving (Show)
 
 data ReportParams = ReportParams { maybeReportBaseDir :: Maybe TurtlePath } deriving (Show)
 
@@ -46,6 +48,7 @@ toRuntimeOptionsImport mainParams' subParams' = do
   return RT.RuntimeOptions { RT.baseDir = bd
                            , RT.importRunDir = runDir
                            , RT.useRunDir = importUseRunDir subParams'
+                           , RT.onlyNewFiles = onlyNewFiles subParams'
                            , RT.hfVersion = versionInfo'
                            , RT.hledgerInfo = hli
                            , RT.sysInfo = systemInfo
@@ -61,6 +64,7 @@ toRuntimeOptionsReport mainParams' subParams' = do
   return RT.RuntimeOptions { RT.baseDir = bd
                            , RT.importRunDir = [reldir|.|]
                            , RT.useRunDir = False
+                           , RT.onlyNewFiles = False
                            , RT.hfVersion = versionInfo'
                            , RT.hledgerInfo = hli
                            , RT.sysInfo = systemInfo
@@ -87,6 +91,7 @@ subcommandParserImport :: Parser ImportParams
 subcommandParserImport = ImportParams
   <$> optional (Turtle.argPath "dir" "The directory to import. Use the base directory for a full import or a sub-directory for a partial import. Defaults to the current directory. This behaviour is changing: see --enable-future-rundir")
   <*> switch (long "enable-future-rundir" <> help "Enable the future (0.14.x) default behaviour now: start importing only from the directory that was given as an argument, or the currect directory. Previously a full import was always done. This switch will be removed in 0.14.x")
+  <*> switch (long "new-files-only" <> help "Don't regenerate transaction files if they are already present. This applies to hledger journal files as well as files produced by the preprocess and construct scripts.")
 
 subcommandParserReport :: Parser ReportParams
 subcommandParserReport = ReportParams

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -211,8 +211,8 @@ verboseTestFile opts ch p = do
   fileExists <- Turtle.testfile p
   let rel = relativeToBase opts p
   if fileExists
-    then logVerbose opts ch $ Turtle.format ("Found a "       %Turtle.fp%" file at '"%Turtle.fp%"'") (Turtle.basename rel) rel
-    else logVerbose opts ch $ Turtle.format ("Did not find a "%Turtle.fp%" file at '"%Turtle.fp%"'") (Turtle.basename rel) rel
+    then logVerbose opts ch $ Turtle.format ("Found '"%Turtle.fp%"'") rel
+    else logVerbose opts ch $ Turtle.format ("Looked for but did not find '"%Turtle.fp%"'") rel
   return fileExists
 
 groupPairs' :: (Eq a, Ord a) => [(a, b)] -> [(a, [b])]

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -8,6 +8,7 @@ import Hledger.Flow.Types
 data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
                                      , importRunDir :: RunDir
                                      , useRunDir :: Bool
+                                     , onlyNewFiles :: Bool
                                      , hfVersion :: T.Text
                                      , hledgerInfo :: HledgerInfo
                                      , sysInfo :: SystemInfo
@@ -18,13 +19,13 @@ data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
   deriving (Show)
 
 instance HasVerbosity RuntimeOptions where
-  verbose (RuntimeOptions _ _ _ _ _ _ v _ _) = v
+  verbose (RuntimeOptions _ _ _ _ _ _ _ v _ _) = v
 
 instance HasSequential RuntimeOptions where
-  sequential (RuntimeOptions _ _ _ _ _ _ _ _ sq) = sq
+  sequential (RuntimeOptions _ _ _ _ _ _ _ _ _ sq) = sq
 
 instance HasBaseDir RuntimeOptions where
-  baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _) = bd
+  baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _ _) = bd
 
 instance HasRunDir RuntimeOptions where
-  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _) = rd
+  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _ _) = rd

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -61,7 +61,18 @@ defaultHlInfo :: FlowTypes.HledgerInfo
 defaultHlInfo = FlowTypes.HledgerInfo "/path/to/hledger" "1.2.3"
 
 defaultOpts :: FlowTypes.BaseDir -> RuntimeOptions
-defaultOpts bd = RuntimeOptions bd [reldir|./|] True versionInfo' defaultHlInfo systemInfo False False False
+defaultOpts bd = RuntimeOptions {
+    baseDir = bd
+  , importRunDir = [reldir|./|]
+  , useRunDir = True
+  , onlyNewFiles = False
+  , hfVersion = versionInfo'
+  , hledgerInfo = defaultHlInfo
+  , sysInfo = systemInfo
+  , verbose = False
+  , showOptions = False
+  , sequential = False
+}
 
 toJournals :: [TurtlePath] -> [TurtlePath]
 toJournals = map (changePathAndExtension "3-journal" "journal")


### PR DESCRIPTION
Don't regenerate transaction files if they are already present. 

This applies to hledger journal files as well as files produced by the preprocess and
construct scripts.