### PR TITLE
Add an optional --start-year command-line option for imports

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,15 @@
 # Changelog for [hledger-flow](https://github.com/apauley/hledger-flow)
 
+## 0.14.2
+
+Add an optional `--start-year` command-line option for imports:
+
+Import only from the specified year and onwards,
+ignoring previous years. Valid values include a 4-digit
+year or 'current' for the current year.
+
+An implementation for [this feature request](https://github.com/apauley/hledger-flow/issues/81)
+
 ## 0.14.1
 
 - Make `--enable-future-rundir` the default, and deprecate the command-line option. To be removed in a future release.

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,7 +14,7 @@ import Hledger.Flow.Common
 import Hledger.Flow.BaseDir
 import qualified Hledger.Flow.RuntimeOptions as RT
 import Hledger.Flow.Reports
-import Hledger.Flow.CSVImport
+import Hledger.Flow.Import.CSVImport
 
 import Control.Monad (when)
 import qualified Data.Text.IO as T

--- a/app/Parsing.hs
+++ b/app/Parsing.hs
@@ -1,0 +1,25 @@
+{-# LANGUAGE PartialTypeSignatures #-}
+
+module Parsing (
+    parseStartYear
+  ) where
+
+import Hledger.Flow.DateTime
+import System.Exit (die)
+import Text.Read (readMaybe)
+
+parseStartYear :: Maybe String -> IO (Maybe Integer)
+parseStartYear y = case y of
+  Nothing -> return Nothing
+  Just "current"  -> Just <$> currentYear
+  Just s -> Just <$> parseInt s "Unable to parse year"
+
+parseInt :: String -> String -> IO Integer
+parseInt s errPrefix = case safeParseInt s errPrefix of
+  Right i -> return i
+  Left err -> die err
+
+safeParseInt :: String -> String -> Either String Integer
+safeParseInt s errPrefix = case (readMaybe s :: Maybe Integer) of
+  Nothing -> Left $ errPrefix ++ " " ++ s
+  Just i  -> Right i

--- a/package.yaml
+++ b/package.yaml
@@ -1,5 +1,5 @@
 name:                hledger-flow
-version:             0.14.1.0
+version:             0.14.2.0
 synopsis:            An hledger workflow focusing on automated statement import and classification.
 category:            Finance, Console
 license:             GPL-3

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -376,7 +376,7 @@ changePathAndExtension newOutputLocation newExt = (changeOutputPath newOutputLoc
 
 changeOutputPath :: TurtlePath -> TurtlePath -> TurtlePath
 changeOutputPath newOutputLocation srcFile = mconcat $ map changeSrcDir $ Turtle.splitDirectories srcFile
-  where changeSrcDir file = if (file == "1-in/" || file == "2-preprocessed/") then newOutputLocation else file
+  where changeSrcDir file = if file == "1-in/" || file == "2-preprocessed/" then newOutputLocation else file
 
 importDirBreakdown ::  TurtlePath -> [TurtlePath]
 importDirBreakdown = importDirBreakdown' []
@@ -384,7 +384,7 @@ importDirBreakdown = importDirBreakdown' []
 importDirBreakdown' :: [TurtlePath] -> TurtlePath -> [TurtlePath]
 importDirBreakdown' acc path = do
   let dir = Turtle.directory path
-  if (Turtle.dirname dir == "import" || (Turtle.dirname dir == ""))
+  if Turtle.dirname dir == "import" || (Turtle.dirname dir == "")
     then dir:acc
     else importDirBreakdown' (dir:acc) $ Turtle.parent dir
 

--- a/src/Hledger/Flow/DateTime.hs
+++ b/src/Hledger/Flow/DateTime.hs
@@ -1,0 +1,12 @@
+module Hledger.Flow.DateTime where
+
+import Data.Time.Clock
+import Data.Time.Calendar
+
+currentDate :: IO (Integer,Int,Int) -- :: (year,month,day)
+currentDate = toGregorian . utctDay <$> getCurrentTime
+
+currentYear :: IO Integer
+currentYear = do
+  (y, _, _) <- currentDate
+  return y

--- a/src/Hledger/Flow/Import/CSVImport.hs
+++ b/src/Hledger/Flow/Import/CSVImport.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Hledger.Flow.CSVImport
+module Hledger.Flow.Import.CSVImport
     ( importCSVs
     ) where
 
@@ -16,6 +16,7 @@ import Hledger.Flow.Import.ImportHelpers
 import Hledger.Flow.PathHelpers (TurtlePath, pathToTurtle)
 import Hledger.Flow.DocHelpers (docURL)
 import Hledger.Flow.Common
+import Hledger.Flow.Logging
 import Hledger.Flow.RuntimeOptions
 import Control.Concurrent.STM
 import Control.Monad

--- a/src/Hledger/Flow/Import/ImportHelpers.hs
+++ b/src/Hledger/Flow/Import/ImportHelpers.hs
@@ -7,21 +7,22 @@ import Data.Char (isDigit)
 
 import Hledger.Flow.PathHelpers (AbsDir, AbsFile, RelDir, findFilesIn)
 
-findInputFiles :: AbsDir -> IO [AbsFile]
-findInputFiles = do
+findInputFiles :: Integer -> AbsDir -> IO [AbsFile]
+findInputFiles startYear = do
   let excludeDirs = [[Path.reldir|2-preprocessed|], [Path.reldir|3-journal|]] ++ commonExcludeDirs
-  findFilesIn (includeYearFilesForParent [Path.reldir|1-in|]) excludeDirs
+  findFilesIn (includeYearFilesForParent [Path.reldir|1-in|] startYear) excludeDirs
 
 findJournalFiles :: AbsDir -> IO [AbsFile]
 findJournalFiles = do
   let excludeDirs = [[Path.reldir|1-in|], [Path.reldir|2-preprocessed|]] ++ commonExcludeDirs
-  findFilesIn (includeYearFilesForParent [Path.reldir|3-journal|]) excludeDirs
+  findFilesIn (includeYearFilesForParent [Path.reldir|3-journal|] 0) excludeDirs
 
 -- | Include only files directly underneath parentDir/yearDir, e.g. 1-in/2020/* or 3-journal/2020/*
-includeYearFilesForParent :: RelDir -> AbsDir -> Bool
-includeYearFilesForParent parentDir d = (dirname . parent) d == parentDir
+includeYearFilesForParent :: RelDir -> Integer -> AbsDir -> Bool
+includeYearFilesForParent parentDir startYear d = (dirname . parent) d == parentDir
   && length shortDirName == 4
   && all isDigit shortDirName
+  && read shortDirName >= startYear
     where shortDirName = dirToStringNoSlash d
 
 dirToStringNoSlash :: AbsDir -> String

--- a/src/Hledger/Flow/Import/ImportHelpers.hs
+++ b/src/Hledger/Flow/Import/ImportHelpers.hs
@@ -1,0 +1,18 @@
+{-# LANGUAGE QuasiQuotes #-}
+
+module Hledger.Flow.Import.ImportHelpers (pathFindFiles) where
+
+import Path
+import Data.Char (isDigit)
+
+import Hledger.Flow.PathHelpers (AbsDir, AbsFile, findFilesIn)
+
+pathFindFiles :: AbsDir -> IO [AbsFile]
+pathFindFiles = do
+  let excludeDirs = [[Path.reldir|2-preprocessed|], [Path.reldir|3-journal|], [Path.reldir|_manual_|], [Path.reldir|__pycache__|]]
+  findFilesIn includePred excludeDirs
+    -- Include only files directly underneath 1-in/yearDir, e.g. 1-in/2020/*
+    where includePred d = (dirname . parent) d == [Path.reldir|1-in|]
+                            && length shortDirName == 4
+                            && all isDigit shortDirName
+            where shortDirName = (init . Path.toFilePath . Path.dirname) d

--- a/src/Hledger/Flow/Import/ImportHelpers.hs
+++ b/src/Hledger/Flow/Import/ImportHelpers.hs
@@ -1,18 +1,31 @@
 {-# LANGUAGE QuasiQuotes #-}
 
-module Hledger.Flow.Import.ImportHelpers (pathFindFiles) where
+module Hledger.Flow.Import.ImportHelpers (findInputFiles, findJournalFiles) where
 
 import Path
 import Data.Char (isDigit)
 
-import Hledger.Flow.PathHelpers (AbsDir, AbsFile, findFilesIn)
+import Hledger.Flow.PathHelpers (AbsDir, AbsFile, RelDir, findFilesIn)
 
-pathFindFiles :: AbsDir -> IO [AbsFile]
-pathFindFiles = do
-  let excludeDirs = [[Path.reldir|2-preprocessed|], [Path.reldir|3-journal|], [Path.reldir|_manual_|], [Path.reldir|__pycache__|]]
-  findFilesIn includePred excludeDirs
-    -- Include only files directly underneath 1-in/yearDir, e.g. 1-in/2020/*
-    where includePred d = (dirname . parent) d == [Path.reldir|1-in|]
-                            && length shortDirName == 4
-                            && all isDigit shortDirName
-            where shortDirName = (init . Path.toFilePath . Path.dirname) d
+findInputFiles :: AbsDir -> IO [AbsFile]
+findInputFiles = do
+  let excludeDirs = [[Path.reldir|2-preprocessed|], [Path.reldir|3-journal|]] ++ commonExcludeDirs
+  findFilesIn (includeYearFilesForParent [Path.reldir|1-in|]) excludeDirs
+
+findJournalFiles :: AbsDir -> IO [AbsFile]
+findJournalFiles = do
+  let excludeDirs = [[Path.reldir|1-in|], [Path.reldir|2-preprocessed|]] ++ commonExcludeDirs
+  findFilesIn (includeYearFilesForParent [Path.reldir|3-journal|]) excludeDirs
+
+-- | Include only files directly underneath parentDir/yearDir, e.g. 1-in/2020/* or 3-journal/2020/*
+includeYearFilesForParent :: RelDir -> AbsDir -> Bool
+includeYearFilesForParent parentDir d = (dirname . parent) d == parentDir
+  && length shortDirName == 4
+  && all isDigit shortDirName
+    where shortDirName = dirToStringNoSlash d
+
+dirToStringNoSlash :: AbsDir -> String
+dirToStringNoSlash = init . Path.toFilePath . Path.dirname
+
+commonExcludeDirs :: [RelDir]
+commonExcludeDirs = [[Path.reldir|_manual_|], [Path.reldir|__pycache__|]]

--- a/src/Hledger/Flow/Logging.hs
+++ b/src/Hledger/Flow/Logging.hs
@@ -1,0 +1,58 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Hledger.Flow.Logging where
+
+import Hledger.Flow.Types
+import Control.Concurrent.STM
+import Control.Monad (when)
+
+import qualified Data.Text as T
+import qualified Data.Text.IO as T
+import Data.Time.LocalTime (getZonedTime)
+
+import qualified GHC.IO.Handle.FD as H
+import qualified Turtle
+import Turtle ((%))
+
+dummyLogger :: TChan LogMessage -> T.Text -> IO ()
+dummyLogger _ _ = return ()
+
+channelOut :: TChan LogMessage -> T.Text -> IO ()
+channelOut ch txt = atomically $ writeTChan ch $ StdOut txt
+
+channelOutLn :: TChan LogMessage -> T.Text -> IO ()
+channelOutLn ch txt = channelOut ch (txt <> "\n")
+
+channelErr :: TChan LogMessage -> T.Text -> IO ()
+channelErr ch txt = atomically $ writeTChan ch $ StdErr txt
+
+channelErrLn :: TChan LogMessage -> T.Text -> IO ()
+channelErrLn ch txt = channelErr ch (txt <> "\n")
+
+logToChannel :: TChan LogMessage -> T.Text -> IO ()
+logToChannel ch msg = do
+  ts <- timestampPrefix msg
+  channelErrLn ch ts
+
+timestampPrefix :: T.Text -> IO T.Text
+timestampPrefix txt = do
+  t <- getZonedTime
+  return $ Turtle.format (Turtle.s%"\thledger-flow "%Turtle.s) (Turtle.repr t) txt
+
+consoleChannelLoop :: TChan LogMessage -> IO ()
+consoleChannelLoop ch = do
+  logMsg <- atomically $ readTChan ch
+  case logMsg of
+    StdOut msg -> do
+      T.hPutStr H.stdout msg
+      consoleChannelLoop ch
+    StdErr msg -> do
+      T.hPutStr H.stderr msg
+      consoleChannelLoop ch
+    Terminate  -> return ()
+
+terminateChannelLoop :: TChan LogMessage -> IO ()
+terminateChannelLoop ch = atomically $ writeTChan ch Terminate
+
+logVerbose :: HasVerbosity o => o -> TChan LogMessage -> T.Text -> IO ()
+logVerbose opts ch msg = when (verbose opts) $ logToChannel ch msg

--- a/src/Hledger/Flow/Reports.hs
+++ b/src/Hledger/Flow/Reports.hs
@@ -19,6 +19,7 @@ import Data.Maybe
 import qualified Data.Text as T
 import qualified Hledger.Flow.Types as FlowTypes
 import Hledger.Flow.PathHelpers (TurtlePath)
+import Hledger.Flow.Logging
 import qualified Data.List as List
 
 data ReportParams = ReportParams { ledgerFile :: TurtlePath

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -7,6 +7,7 @@ import Hledger.Flow.Types
 
 data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
                                      , importRunDir :: RunDir
+                                     , importStartYear :: Maybe Integer
                                      , onlyNewFiles :: Bool
                                      , hfVersion :: T.Text
                                      , hledgerInfo :: HledgerInfo
@@ -18,13 +19,13 @@ data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
   deriving (Show)
 
 instance HasVerbosity RuntimeOptions where
-  verbose (RuntimeOptions _ _ _ _ _ _ v _ _) = v
+  verbose (RuntimeOptions _ _ _ _ _ _ _ v _ _) = v
 
 instance HasSequential RuntimeOptions where
-  sequential (RuntimeOptions _ _ _ _ _ _ _ _ sq) = sq
+  sequential (RuntimeOptions _ _ _ _ _ _ _ _ _ sq) = sq
 
 instance HasBaseDir RuntimeOptions where
-  baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _) = bd
+  baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _ _) = bd
 
 instance HasRunDir RuntimeOptions where
-  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _) = rd
+  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _ _) = rd

--- a/src/Hledger/Flow/Types.hs
+++ b/src/Hledger/Flow/Types.hs
@@ -1,10 +1,9 @@
 {-# LANGUAGE TypeSynonymInstances #-}
 {-# LANGUAGE FlexibleInstances #-}
 
-module Hledger.Flow.Types
-where
+module Hledger.Flow.Types where
 
-import qualified Turtle as Turtle (ExitCode, NominalDiffTime, Shell, Line)
+import qualified Turtle (ExitCode, NominalDiffTime, Shell, Line)
 import qualified Data.Text as T
 import Data.Version
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -18,7 +18,7 @@
 #
 # resolver: ./custom-snapshot.yaml
 # resolver: https://example.com/snapshots/2018-01-01.yaml
-resolver: nightly-2020-09-02
+resolver: nightly-2020-09-06
 
 # User packages to be built.
 # Various formats can be used as shown in the example below.

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 527775
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/9/2.yaml
-    sha256: 92ec78ae38830f06ec9307c5ce346ae93982fab6179eb10dec9d57d5069c7f14
-  original: nightly-2020-09-02
+    size: 528634
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/nightly/2020/9/6.yaml
+    sha256: 89ea4655110abf21b7c9b541a0ec0bfe6f222f0d995cfefd3d08eb385f49ad02
+  original: nightly-2020-09-06

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -64,6 +64,7 @@ defaultOpts :: FlowTypes.BaseDir -> RuntimeOptions
 defaultOpts bd = RuntimeOptions {
     baseDir = bd
   , importRunDir = [reldir|./|]
+  , importStartYear = Nothing
   , onlyNewFiles = False
   , hfVersion = versionInfo'
   , hledgerInfo = defaultHlInfo


### PR DESCRIPTION
Import only from the specified year and onwards, ignoring previous years. 
Valid values include a 4-digit year or 'current' for the current year.

Fixes #81 