### PR TITLE
Add --ascii-reports flag.

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -38,7 +38,9 @@ data ImportParams = ImportParams { maybeImportBaseDir :: Maybe TurtlePath
                                  , onlyNewFiles :: Bool
                                  } deriving (Show)
 
-newtype ReportParams = ReportParams {maybeReportBaseDir :: Maybe TurtlePath} deriving Show
+data ReportParams = ReportParams { maybeReportBaseDir :: Maybe TurtlePath
+                                 , asciiReports :: Bool
+                                 } deriving (Show)
 
 data Command = Import ImportParams | Report ReportParams deriving (Show)
 
@@ -88,6 +90,7 @@ toRuntimeOptionsImport mainParams' subParams' = do
                            , RT.showOptions = showOpts mainParams'
                            , RT.sequential = sequential mainParams'
                            , RT.batchSize = size
+                           , RT.prettyReports = True
                            }
 
 toRuntimeOptionsReport :: MainParams -> ReportParams -> IO RT.RuntimeOptions
@@ -108,6 +111,7 @@ toRuntimeOptionsReport mainParams' subParams' = do
                            , RT.showOptions = showOpts mainParams'
                            , RT.sequential = sequential mainParams'
                            , RT.batchSize = size
+                           , RT.prettyReports = not(asciiReports subParams')
                            }
 
 baseCommandParser :: Parser BaseCommand
@@ -135,3 +139,4 @@ subcommandParserImport = ImportParams
 subcommandParserReport :: Parser ReportParams
 subcommandParserReport = ReportParams
   <$> optional (Turtle.argPath "basedir" "The hledger-flow base directory")
+  <*> switch (long "ascii-reports" <> help "If to avoid using hledger --pretty-tables flag when generating reports.")

--- a/src/Hledger/Flow/Reports.hs
+++ b/src/Hledger/Flow/Reports.hs
@@ -63,7 +63,7 @@ generateReports' opts ch = do
   let aggregateOnlyReports = reportActions opts ch [transferBalance] aggregateParams
   ownerParams <- ownerParameters opts ch owners
   let ownerWithAggregateParams = (if length owners > 1 then [aggregateParams] else []) ++ ownerParams
-  let sharedOptions = ["--pretty-tables", "--depth", "2"]
+  let sharedOptions = (if prettyReports opts then ["--pretty-tables"] else []) ++ ["--depth", "2"]
   let ownerWithAggregateReports = List.concat $ fmap (reportActions opts ch [incomeStatement sharedOptions, incomeMonthlyStatement sharedOptions, balanceSheet sharedOptions]) ownerWithAggregateParams
   let ownerOnlyReports = List.concat $ fmap (reportActions opts ch [accountList, unknownTransactions]) ownerParams
   parAwareActions opts (aggregateOnlyReports ++ ownerWithAggregateReports ++ ownerOnlyReports)
@@ -100,7 +100,7 @@ balanceSheet sharedOptions opts ch journal baseOutDir year = do
 
 transferBalance :: ReportGenerator
 transferBalance opts ch journal baseOutDir year = do
-  let reportArgs = ["balance", "--pretty-tables", "--quarterly", "--flat", "--no-total", "transfer"]
+  let reportArgs = ["balance"] ++ (if prettyReports opts then ["--pretty-tables"] else []) ++ ["--quarterly", "--flat", "--no-total", "transfer"]
   generateReport opts ch journal year (baseOutDir </> intPath year) ("transfer-balance" <.> "txt") reportArgs (\txt -> (length $ T.lines txt) > 4)
 
 generateReport :: RuntimeOptions -> TChan FlowTypes.LogMessage -> TurtlePath -> Integer -> TurtlePath -> TurtlePath -> [T.Text] -> (T.Text -> Bool) -> IO (Either TurtlePath TurtlePath)

--- a/src/Hledger/Flow/RuntimeOptions.hs
+++ b/src/Hledger/Flow/RuntimeOptions.hs
@@ -17,20 +17,25 @@ data RuntimeOptions = RuntimeOptions { baseDir :: BaseDir
                                      , showOptions :: Bool
                                      , sequential :: Bool
                                      , batchSize :: Int
+                                     , prettyReports :: Bool
                                      }
   deriving (Show)
 
 instance HasVerbosity RuntimeOptions where
-  verbose (RuntimeOptions _ _ _ _ _ _ _ v _ _ _) = v
+  verbose (RuntimeOptions _ _ _ _ _ _ _ v _ _ _ _) = v
 
 instance HasSequential RuntimeOptions where
-  sequential (RuntimeOptions _ _ _ _ _ _ _ _ _ sq _) = sq
+  sequential (RuntimeOptions _ _ _ _ _ _ _ _ _ sq _ _) = sq
 
 instance HasBatchSize RuntimeOptions where
-  batchSize (RuntimeOptions _ _ _ _ _ _ _ _ _ _ bs) = bs
+  batchSize (RuntimeOptions _ _ _ _ _ _ _ _ _ _ bs _) = bs
 
 instance HasBaseDir RuntimeOptions where
-  baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _ _ _) = bd
+  baseDir (RuntimeOptions bd _ _ _ _ _ _ _ _ _ _ _) = bd
 
 instance HasRunDir RuntimeOptions where
-  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _ _ _) = rd
+  importRunDir (RuntimeOptions _ rd _ _ _ _ _ _ _ _ _ _) = rd
+
+instance HasPrettyReports RuntimeOptions where
+  prettyReports (RuntimeOptions _ _ _ _ _ _ _ _ _ _ _ pr) = pr
+

--- a/src/Hledger/Flow/Types.hs
+++ b/src/Hledger/Flow/Types.hs
@@ -36,3 +36,6 @@ class HasSequential a where
 
 class HasBatchSize a where
   batchSize :: a -> Int
+
+class HasPrettyReports a where
+  prettyReports :: a -> Bool

--- a/test/TestHelpers.hs
+++ b/test/TestHelpers.hs
@@ -40,6 +40,7 @@ defaultOpts bd = RuntimeOptions {
   , showOptions = False
   , sequential = False
   , batchSize = 1
+  , prettyReports = True
 }
 
 toJournal :: RelFile -> RelFile


### PR DESCRIPTION
This allows to disable pretty tables generated by hledger. Pretty tables include non-ascii tables, which causes encoding-caused crashes of hledger-flow.

I have a rather weird nix + non-nix setup of binaries. I was not able to get encodings to work correctly between hledger and hledger-flow. This works around the problem completely.