### PR TITLE
Change --new-files-only to mtime-based comparison

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ releases/
 .idea
 *.iml
 .DS_Store
+
+# ralphex progress logs
+.ralphex/progress/

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,13 @@
 # Changelog for [hledger-flow](https://github.com/apauley/hledger-flow)
 
+## 0.16.3
+
+- Change `--new-files-only` to use modification time comparison instead of existence check.
+  Previously, this flag skipped regeneration only if output files existed.
+  Now it compares source and target modification times, allowing automatic
+  reprocessing when source files are updated. Note: changes to rules files
+  or construct/preprocess scripts are not tracked.
+
 ## 0.16.2
 
  - Add a Github Actions workflow, contributed by [Udit Desai](https://github.com/apauley/hledger-flow/issues?q=author%3Adesaiuditd)

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -134,7 +134,7 @@ subcommandParserImport :: Parser ImportParams
 subcommandParserImport = ImportParams
   <$> optional (Turtle.argPath "dir" "The directory to import. Use the base directory for a full import or a sub-directory for a partial import. Defaults to the current directory.")
   <*> optional (option str (long "start-year" <> metavar "YEAR" <> help "Import only from the specified year and onwards, ignoring previous years. By default all available years are imported. Valid values include a 4-digit year or 'current' for the current year"))
-  <*> switch (long "new-files-only" <> help "Skip regenerating output files that are newer than their source. This applies to preprocessed files, hledger journal files, and construct script outputs.")
+  <*> switch (long "new-files-only" <> help "Skip regenerating output files that are at least as new as their source. This applies to preprocessed files, hledger journal files, and construct script outputs.")
 
 subcommandParserReport :: Parser ReportParams
 subcommandParserReport = ReportParams

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -134,7 +134,7 @@ subcommandParserImport :: Parser ImportParams
 subcommandParserImport = ImportParams
   <$> optional (Turtle.argPath "dir" "The directory to import. Use the base directory for a full import or a sub-directory for a partial import. Defaults to the current directory.")
   <*> optional (option str (long "start-year" <> metavar "YEAR" <> help "Import only from the specified year and onwards, ignoring previous years. By default all available years are imported. Valid values include a 4-digit year or 'current' for the current year"))
-  <*> switch (long "new-files-only" <> help "Skip regenerating output files that are at least as new as their source. This applies to preprocessed files, hledger journal files, and construct script outputs.")
+  <*> switch (long "new-files-only" <> help "Skip regenerating output files that are at least as new as their source. This applies to preprocessed files and hledger journal files.")
 
 subcommandParserReport :: Parser ReportParams
 subcommandParserReport = ReportParams

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -134,7 +134,7 @@ subcommandParserImport :: Parser ImportParams
 subcommandParserImport = ImportParams
   <$> optional (Turtle.argPath "dir" "The directory to import. Use the base directory for a full import or a sub-directory for a partial import. Defaults to the current directory.")
   <*> optional (option str (long "start-year" <> metavar "YEAR" <> help "Import only from the specified year and onwards, ignoring previous years. By default all available years are imported. Valid values include a 4-digit year or 'current' for the current year"))
-  <*> switch (long "new-files-only" <> help "Don't regenerate transaction files if they are already present. This applies to hledger journal files as well as files produced by the preprocess and construct scripts.")
+  <*> switch (long "new-files-only" <> help "Skip regenerating output files that are newer than their source. This applies to preprocessed files, hledger journal files, and construct script outputs.")
 
 subcommandParserReport :: Parser ReportParams
 subcommandParserReport = ReportParams

--- a/docs/plans/20260313-new-files-only-mtime.md
+++ b/docs/plans/20260313-new-files-only-mtime.md
@@ -69,9 +69,9 @@
 **Files:**
 - Modify: `src/Hledger/Flow/Import/CSVImport.hs`
 
-- [ ] Replace `not <$> verboseTestFile opts ch journalOut` with `needsRegeneration csvFile journalOut`
-- [ ] Verify the `preprocessHappened` check is preserved (if we just preprocessed, always import)
-- [ ] Run `stack test` - all tests must pass before next task
+- [x] Replace `not <$> verboseTestFile opts ch journalOut` with `needsRegeneration csvFile journalOut`
+- [x] Verify the `preprocessHappened` check is preserved (if we just preprocessed, always import)
+- [x] Run `stack test` - all tests must pass before next task
 
 ### Task 4: Update help text
 

--- a/docs/plans/20260313-new-files-only-mtime.md
+++ b/docs/plans/20260313-new-files-only-mtime.md
@@ -1,0 +1,138 @@
+# Add mtime-based regeneration to --new-files-only flag
+
+## Overview
+- Enhance the `--new-files-only` flag to compare modification times between source and target files
+- Currently the flag only checks if target exists; this improvement reprocesses when source is newer than target
+- Enables incremental rebuilds when source files are updated without requiring full reimport
+
+## Context (from discovery)
+- Files involved:
+  - `src/Hledger/Flow/Common.hs` - add helper function
+  - `src/Hledger/Flow/Import/CSVImport.hs` - integrate helper at two points
+  - `app/Main.hs` - update help text
+- Related patterns: `verboseTestFile` exists in Common.hs for file existence checks
+- Dependencies: `Turtle.modtime` returns `UTCTime`, directly comparable with `>`
+
+## Development Approach
+- **Testing approach**: Regular (code first, then tests)
+- Complete each task fully before moving to the next
+- Make small, focused changes
+- **CRITICAL: every task MUST include new/updated tests** for code changes in that task
+- **CRITICAL: all tests must pass before starting next task**
+- Run tests after each change with `stack test`
+- Maintain backward compatibility
+
+## Testing Strategy
+- **Unit tests**: Test `needsRegeneration` helper function
+- Test cases:
+  - Target doesn't exist → returns True
+  - Target exists, source newer → returns True
+  - Target exists, target newer → returns False
+  - Target exists, same mtime → returns False
+
+## Progress Tracking
+- Mark completed items with `[x]` immediately when done
+- Add newly discovered tasks with ➕ prefix
+- Document issues/blockers with ⚠️ prefix
+
+## Implementation Steps
+
+### Task 1: Add needsRegeneration helper function with tests
+
+**Files:**
+- Modify: `src/Hledger/Flow/Common.hs`
+- Modify: `test/Common/Integration.hs`
+
+- [ ] Add `needsRegeneration :: TurtlePath -> TurtlePath -> IO Bool` function to Common.hs
+- [ ] Implement logic: return True if target doesn't exist OR source mtime > target mtime
+- [ ] Use `Turtle.testfile` for existence and `Turtle.modtime` for mtime comparison
+- [ ] Export the function from the module
+- [ ] Add `testNeedsRegeneration` test in `test/Common/Integration.hs` following `testFirstExistingFile` pattern
+- [ ] Write test case: target doesn't exist → returns True
+- [ ] Write test case: target exists, source newer → returns True (use sleep or touch with delay)
+- [ ] Write test case: target exists, target newer → returns False
+- [ ] Add test to the `tests` list in Integration.hs
+- [ ] Run `stack test` - all tests must pass before next task
+
+### Task 2: Integrate needsRegeneration in preprocessIfNeeded
+
+**Files:**
+- Modify: `src/Hledger/Flow/Import/CSVImport.hs`
+
+- [ ] Import `needsRegeneration` from Common module (if not already re-exported)
+- [ ] Replace `not targetExists` check with `needsRegeneration src csvOut` call
+- [ ] Update the `shouldProceed` logic to use the new helper
+- [ ] Run `stack test` - all tests must pass before next task
+
+### Task 3: Integrate needsRegeneration in importCSV
+
+**Files:**
+- Modify: `src/Hledger/Flow/Import/CSVImport.hs`
+
+- [ ] Replace `not <$> verboseTestFile opts ch journalOut` with `needsRegeneration csvFile journalOut`
+- [ ] Verify the `preprocessHappened` check is preserved (if we just preprocessed, always import)
+- [ ] Run `stack test` - all tests must pass before next task
+
+### Task 4: Update help text
+
+**Files:**
+- Modify: `app/Main.hs`
+
+- [ ] Update `--new-files-only` help text from existence-based to mtime-based description
+- [ ] New text: "Skip regenerating output files that are newer than their source. This applies to preprocessed files, hledger journal files, and construct script outputs."
+- [ ] Run `stack test` - all tests must pass before next task
+
+### Task 5: Verify acceptance criteria
+
+- [ ] Verify `--new-files-only` skips files when target is newer than source
+- [ ] Verify `--new-files-only` reprocesses when source is newer than target
+- [ ] Verify preprocessing and import stages both respect mtime
+- [ ] Run full test suite: `stack test`
+
+### Task 6: [Final] Cleanup
+
+- [ ] Update CLAUDE.md if new patterns discovered
+- [ ] Move this plan to `docs/plans/completed/`
+
+## Technical Details
+
+**needsRegeneration function**:
+```haskell
+needsRegeneration :: TurtlePath -> TurtlePath -> IO Bool
+needsRegeneration src target = do
+  targetExists <- Turtle.testfile target
+  if not targetExists
+    then return True
+    else do
+      srcMtime <- Turtle.modtime src
+      targetMtime <- Turtle.modtime target
+      return (srcMtime > targetMtime)
+```
+
+**Integration in preprocessIfNeeded** (lines 112-114):
+```haskell
+shouldProceed <-
+  if onlyNewFiles opts
+    then do
+      needsRegen <- needsRegeneration src csvOut
+      return $ scriptExists && needsRegen
+    else return scriptExists
+```
+
+**Integration in importCSV** (lines 85-88):
+```haskell
+shouldImport <-
+  if onlyNewFiles opts && not preprocessHappened
+    then needsRegeneration csvFile journalOut
+    else return True
+```
+
+## Post-Completion
+
+**Manual verification**:
+- Test with actual statement files to verify mtime comparison works correctly
+- Test touching a source file and re-running import with `--new-files-only`
+
+**Edge cases to verify manually**:
+- Rules file changes are NOT tracked (documented limitation)
+- Construct/preprocess script changes are NOT tracked (documented limitation)

--- a/docs/plans/20260313-new-files-only-mtime.md
+++ b/docs/plans/20260313-new-files-only-mtime.md
@@ -43,16 +43,16 @@
 - Modify: `src/Hledger/Flow/Common.hs`
 - Modify: `test/Common/Integration.hs`
 
-- [ ] Add `needsRegeneration :: TurtlePath -> TurtlePath -> IO Bool` function to Common.hs
-- [ ] Implement logic: return True if target doesn't exist OR source mtime > target mtime
-- [ ] Use `Turtle.testfile` for existence and `Turtle.modtime` for mtime comparison
-- [ ] Export the function from the module
-- [ ] Add `testNeedsRegeneration` test in `test/Common/Integration.hs` following `testFirstExistingFile` pattern
-- [ ] Write test case: target doesn't exist → returns True
-- [ ] Write test case: target exists, source newer → returns True (use sleep or touch with delay)
-- [ ] Write test case: target exists, target newer → returns False
-- [ ] Add test to the `tests` list in Integration.hs
-- [ ] Run `stack test` - all tests must pass before next task
+- [x] Add `needsRegeneration :: TurtlePath -> TurtlePath -> IO Bool` function to Common.hs
+- [x] Implement logic: return True if target doesn't exist OR source mtime > target mtime
+- [x] Use `Turtle.testfile` for existence and `Turtle.modtime` for mtime comparison
+- [x] Export the function from the module
+- [x] Add `testNeedsRegeneration` test in `test/Common/Integration.hs` following `testFirstExistingFile` pattern
+- [x] Write test case: target doesn't exist → returns True
+- [x] Write test case: target exists, source newer → returns True (use sleep or touch with delay)
+- [x] Write test case: target exists, target newer → returns False
+- [x] Add test to the `tests` list in Integration.hs
+- [x] Run `stack test` - all tests must pass before next task
 
 ### Task 2: Integrate needsRegeneration in preprocessIfNeeded
 

--- a/docs/plans/20260313-new-files-only-mtime.md
+++ b/docs/plans/20260313-new-files-only-mtime.md
@@ -59,10 +59,10 @@
 **Files:**
 - Modify: `src/Hledger/Flow/Import/CSVImport.hs`
 
-- [ ] Import `needsRegeneration` from Common module (if not already re-exported)
-- [ ] Replace `not targetExists` check with `needsRegeneration src csvOut` call
-- [ ] Update the `shouldProceed` logic to use the new helper
-- [ ] Run `stack test` - all tests must pass before next task
+- [x] Import `needsRegeneration` from Common module (if not already re-exported)
+- [x] Replace `not targetExists` check with `needsRegeneration src csvOut` call
+- [x] Update the `shouldProceed` logic to use the new helper
+- [x] Run `stack test` - all tests must pass before next task
 
 ### Task 3: Integrate needsRegeneration in importCSV
 

--- a/docs/plans/20260313-new-files-only-mtime.md
+++ b/docs/plans/20260313-new-files-only-mtime.md
@@ -78,9 +78,9 @@
 **Files:**
 - Modify: `app/Main.hs`
 
-- [ ] Update `--new-files-only` help text from existence-based to mtime-based description
-- [ ] New text: "Skip regenerating output files that are newer than their source. This applies to preprocessed files, hledger journal files, and construct script outputs."
-- [ ] Run `stack test` - all tests must pass before next task
+- [x] Update `--new-files-only` help text from existence-based to mtime-based description
+- [x] New text: "Skip regenerating output files that are newer than their source. This applies to preprocessed files, hledger journal files, and construct script outputs."
+- [x] Run `stack test` - all tests must pass before next task
 
 ### Task 5: Verify acceptance criteria
 

--- a/docs/plans/20260313-new-files-only-mtime.md
+++ b/docs/plans/20260313-new-files-only-mtime.md
@@ -84,10 +84,10 @@
 
 ### Task 5: Verify acceptance criteria
 
-- [ ] Verify `--new-files-only` skips files when target is newer than source
-- [ ] Verify `--new-files-only` reprocesses when source is newer than target
-- [ ] Verify preprocessing and import stages both respect mtime
-- [ ] Run full test suite: `stack test`
+- [x] Verify `--new-files-only` skips files when target is newer than source
+- [x] Verify `--new-files-only` reprocesses when source is newer than target
+- [x] Verify preprocessing and import stages both respect mtime
+- [x] Run full test suite: `stack test`
 
 ### Task 6: [Final] Cleanup
 

--- a/docs/plans/completed/20260313-new-files-only-mtime.md
+++ b/docs/plans/completed/20260313-new-files-only-mtime.md
@@ -91,8 +91,8 @@
 
 ### Task 6: [Final] Cleanup
 
-- [ ] Update CLAUDE.md if new patterns discovered
-- [ ] Move this plan to `docs/plans/completed/`
+- [x] Update CLAUDE.md if new patterns discovered
+- [x] Move this plan to `docs/plans/completed/`
 
 ## Technical Details
 

--- a/package.yaml
+++ b/package.yaml
@@ -77,6 +77,8 @@ tests:
       - turtle
       - HUnit
       - containers
+      - directory
       - foldl
       - text
+      - time
       - stm

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -1,9 +1,11 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE QuasiQuotes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 
 module Hledger.Flow.Common where
 
 import Control.Concurrent.STM
+import Control.Exception (IOException, try)
 import qualified Control.Foldl as Fold
 import Data.Char (isDigit)
 import Data.Either
@@ -200,11 +202,17 @@ needsRegeneration src target = do
   if not targetExists
     then return True
     else do
-      srcStat <- Turtle.stat src
-      targetStat <- Turtle.stat target
-      let srcMtime = Turtle.modificationTime srcStat
-      let targetMtime = Turtle.modificationTime targetStat
-      return (srcMtime > targetMtime)
+      -- Use try to handle race conditions where files may be modified/deleted
+      -- between existence check and stat. Treat any IO error as "needs regeneration".
+      result <- try $ do
+        srcStat <- Turtle.stat src
+        targetStat <- Turtle.stat target
+        let srcMtime = Turtle.modificationTime srcStat
+        let targetMtime = Turtle.modificationTime targetStat
+        return (srcMtime > targetMtime)
+      case result of
+        Right needsRegen -> return needsRegen
+        Left (_ :: IOException) -> return True
 
 groupPairs' :: (Eq a, Ord a) => [(a, b)] -> [(a, [b])]
 groupPairs' =

--- a/src/Hledger/Flow/Common.hs
+++ b/src/Hledger/Flow/Common.hs
@@ -194,6 +194,18 @@ verboseTestFile opts ch p = do
     else logVerbose opts ch $ Turtle.format ("Looked for but did not find '" % Turtle.fp % "'") rel
   return fileExists
 
+needsRegeneration :: TurtlePath -> TurtlePath -> IO Bool
+needsRegeneration src target = do
+  targetExists <- Turtle.testfile target
+  if not targetExists
+    then return True
+    else do
+      srcStat <- Turtle.stat src
+      targetStat <- Turtle.stat target
+      let srcMtime = Turtle.modificationTime srcStat
+      let targetMtime = Turtle.modificationTime targetStat
+      return (srcMtime > targetMtime)
+
 groupPairs' :: (Eq a, Ord a) => [(a, b)] -> [(a, [b])]
 groupPairs' =
   mapMaybe

--- a/src/Hledger/Flow/Import/CSVImport.hs
+++ b/src/Hledger/Flow/Import/CSVImport.hs
@@ -119,7 +119,9 @@ preprocessIfNeeded opts ch script bank account owner src = do
   targetExists <- verboseTestFile opts ch csvOut
   shouldProceed <-
     if onlyNewFiles opts
-      then return $ scriptExists && not targetExists
+      then do
+        needsRegen <- needsRegeneration src csvOut
+        return $ scriptExists && needsRegen
       else return scriptExists
   if shouldProceed
     then do

--- a/src/Hledger/Flow/Import/CSVImport.hs
+++ b/src/Hledger/Flow/Import/CSVImport.hs
@@ -92,7 +92,7 @@ importCSV opts ch importDirs srcFile = do
   let journalOut = changePathAndExtension "3-journal/" "journal" csvFile
   shouldImport <-
     if onlyNewFiles opts && not preprocessHappened
-      then not <$> verboseTestFile opts ch journalOut
+      then needsRegeneration csvFile journalOut
       else return True
 
   importFun <-

--- a/src/Hledger/Flow/Import/CSVImport.hs
+++ b/src/Hledger/Flow/Import/CSVImport.hs
@@ -118,17 +118,17 @@ preprocessIfNeeded opts ch script bank account owner src = do
   scriptExists <- verboseTestFile opts ch script
   targetExists <- verboseTestFile opts ch csvOut
   shouldProceed <-
-    if onlyNewFiles opts
+    if onlyNewFiles opts && scriptExists
       then do
         needsRegen <- needsRegeneration src csvOut
-        return $ scriptExists && needsRegen
+        Control.Monad.unless needsRegen $ logNewFileSkip opts ch "preprocess" csvOut
+        return needsRegen
       else return scriptExists
   if shouldProceed
     then do
       out <- preprocess opts ch script bank account owner src csvOut
       return (out, True)
     else do
-      _ <- logNewFileSkip opts ch "preprocess" csvOut
       if targetExists
         then return (csvOut, False)
         else return (src, False)
@@ -141,7 +141,7 @@ logNewFileSkip opts ch logIdentifier absTarget =
       Turtle.format
         ( "Skipping "
             % Turtle.s
-            % " - only creating new files and this output file already exists: '"
+            % " - output file is at least as new as source: '"
             % Turtle.fp
             % "'"
         )

--- a/step-by-step/part1.org
+++ b/step-by-step/part1.org
@@ -117,8 +117,8 @@ Available options:
                            years are imported. Valid values include a 4-digit
                            year or 'current' for the current year
   --new-files-only         Skip regenerating output files that are at least as
-                           new as their source. This applies to preprocessed files,
-                           hledger journal files, and construct script outputs.
+                           new as their source. This applies to preprocessed files
+                           and hledger journal files.
   -h,--help                Show this help text
 
 #+end_src

--- a/step-by-step/part1.org
+++ b/step-by-step/part1.org
@@ -116,10 +116,9 @@ Available options:
                            ignoring previous years. By default all available
                            years are imported. Valid values include a 4-digit
                            year or 'current' for the current year
-  --new-files-only         Don't regenerate transaction files if they are
-                           already present. This applies to hledger journal
-                           files as well as files produced by the preprocess and
-                           construct scripts.
+  --new-files-only         Skip regenerating output files that are at least as
+                           new as their source. This applies to preprocessed files,
+                           hledger journal files, and construct script outputs.
   -h,--help                Show this help text
 
 #+end_src

--- a/test/Common/Integration.hs
+++ b/test/Common/Integration.hs
@@ -72,5 +72,36 @@ testFirstExistingFile =
         )
     )
 
+testNeedsRegeneration :: Test
+testNeedsRegeneration =
+  TestCase
+    ( sh
+        ( do
+            let tmpbase = "." </> "test" </> "tmp"
+            mktree tmpbase
+            tmpdir <- using (mktempdir tmpbase "hlflowtest")
+            let source = tmpdir </> "source.txt"
+            let target = tmpdir </> "target.txt"
+
+            -- Test case 1: target doesn't exist -> returns True
+            touch source
+            result1 <- liftIO $ needsRegeneration source target
+            liftIO $ assertEqual "Should return True when target doesn't exist" True result1
+
+            -- Test case 2: target exists, source is newer -> returns True
+            touch target
+            sleep 1.1  -- Ensure time difference (filesystem resolution can be 1 second)
+            touch source  -- Make source newer
+            result2 <- liftIO $ needsRegeneration source target
+            liftIO $ assertEqual "Should return True when source is newer than target" True result2
+
+            -- Test case 3: target exists, target is newer -> returns False
+            sleep 1.1  -- Ensure time difference (filesystem resolution can be 1 second)
+            touch target  -- Make target newer
+            result3 <- liftIO $ needsRegeneration source target
+            liftIO $ assertEqual "Should return False when target is newer than source" False result3
+        )
+    )
+
 tests :: Test
-tests = TestList [testHiddenFiles, testFilterPaths, testFirstExistingFile]
+tests = TestList [testHiddenFiles, testFilterPaths, testFirstExistingFile, testNeedsRegeneration]

--- a/test/Common/Integration.hs
+++ b/test/Common/Integration.hs
@@ -4,8 +4,11 @@
 module Common.Integration (tests) where
 
 import qualified Data.List as List (sort)
+import Data.Time.Clock (UTCTime(..), secondsToDiffTime)
+import Data.Time.Calendar (fromGregorian)
 import Hledger.Flow.Common
 import Hledger.Flow.PathHelpers (TurtlePath)
+import qualified System.Directory as Dir
 import Test.HUnit
 import TestHelpersTurtle
 import Turtle
@@ -72,6 +75,17 @@ testFirstExistingFile =
         )
     )
 
+-- Helper to set mtime on a Turtle path
+setMtime :: TurtlePath -> UTCTime -> IO ()
+setMtime path time = Dir.setModificationTime path time
+
+-- Fixed timestamps for deterministic tests
+olderTime :: UTCTime
+olderTime = UTCTime (fromGregorian 2020 1 1) (secondsToDiffTime 0)
+
+newerTime :: UTCTime
+newerTime = UTCTime (fromGregorian 2025 1 1) (secondsToDiffTime 0)
+
 testNeedsRegeneration :: Test
 testNeedsRegeneration =
   TestCase
@@ -90,33 +104,22 @@ testNeedsRegeneration =
 
             -- Test case 2: target exists, source is newer -> returns True
             touch target
-            sleep 1.1  -- Ensure time difference (filesystem resolution can be 1 second)
-            touch source  -- Make source newer
+            liftIO $ setMtime target olderTime
+            liftIO $ setMtime source newerTime
             result2 <- liftIO $ needsRegeneration source target
             liftIO $ assertEqual "Should return True when source is newer than target" True result2
 
             -- Test case 3: target exists, target is newer -> returns False
-            sleep 1.1  -- Ensure time difference (filesystem resolution can be 1 second)
-            touch target  -- Make target newer
+            liftIO $ setMtime source olderTime
+            liftIO $ setMtime target newerTime
             result3 <- liftIO $ needsRegeneration source target
             liftIO $ assertEqual "Should return False when target is newer than source" False result3
 
             -- Test case 4: equal mtimes -> returns False (boundary condition)
-            -- Comparing a file to itself guarantees equal mtimes
-            let sourceEq = tmpdir </> "sourceEq.txt"
-            touch sourceEq
-            result4Eq <- liftIO $ needsRegeneration sourceEq sourceEq
-            liftIO $ assertEqual "Should return False when mtimes are equal" False result4Eq
-
-            -- Test case 5: target exists, target newer (via copy which gets current time) -> returns False
-            -- Turtle.cp does NOT preserve mtime - target gets current time (newer than source)
-            let source2 = tmpdir </> "source2.txt"
-            let target2 = tmpdir </> "target2.txt"
-            touch source2
-            sleep 1.1  -- Delay to ensure target gets later timestamp (consistent with other tests)
-            Turtle.cp source2 target2  -- target gets current time, not source mtime
-            result5 <- liftIO $ needsRegeneration source2 target2
-            liftIO $ assertEqual "Should return False when target is newer than source (via copy)" False result5
+            liftIO $ setMtime source olderTime
+            liftIO $ setMtime target olderTime
+            result4 <- liftIO $ needsRegeneration source target
+            liftIO $ assertEqual "Should return False when mtimes are equal" False result4
         )
     )
 

--- a/test/Common/Integration.hs
+++ b/test/Common/Integration.hs
@@ -100,6 +100,23 @@ testNeedsRegeneration =
             touch target  -- Make target newer
             result3 <- liftIO $ needsRegeneration source target
             liftIO $ assertEqual "Should return False when target is newer than source" False result3
+
+            -- Test case 4: equal mtimes -> returns False (boundary condition)
+            -- Comparing a file to itself guarantees equal mtimes
+            let sourceEq = tmpdir </> "sourceEq.txt"
+            touch sourceEq
+            result4Eq <- liftIO $ needsRegeneration sourceEq sourceEq
+            liftIO $ assertEqual "Should return False when mtimes are equal" False result4Eq
+
+            -- Test case 5: target exists, target newer (via copy which gets current time) -> returns False
+            -- Turtle.cp does NOT preserve mtime - target gets current time (newer than source)
+            let source2 = tmpdir </> "source2.txt"
+            let target2 = tmpdir </> "target2.txt"
+            touch source2
+            sleep 1.1  -- Delay to ensure target gets later timestamp (consistent with other tests)
+            Turtle.cp source2 target2  -- target gets current time, not source mtime
+            result5 <- liftIO $ needsRegeneration source2 target2
+            liftIO $ assertEqual "Should return False when target is newer than source (via copy)" False result5
         )
     )
 


### PR DESCRIPTION
**Summary**

- Changed `--new-files-only` behavior from existence-based to mtime-based comparison
- Output files now regenerate when source is newer, not just when target is missing
- Added `needsRegeneration` helper with exception handling for race conditions

**Changes**

- `needsRegeneration` function in `Common.hs` - compares source/target mtime, returns True if target missing or source newer
- Updated `preprocessIfNeeded` and `importCSV` to use mtime comparison instead of existence check
- Help text updated to reflect new behavior
- Integration tests cover all edge cases: missing target, source newer, target newer, equal mtimes

**Test plan**

- [x] `stack test` passes
- [x] Verified `--new-files-only` skips when target newer than source
- [x] Verified `--new-files-only` regenerates when source newer than target
- [x] Both preprocess and import stages respect mtime
